### PR TITLE
Feature: Cache scores list.

### DIFF
--- a/lib/model/xidian_ids/score.dart
+++ b/lib/model/xidian_ids/score.dart
@@ -3,6 +3,11 @@
 
 // ignore_for_file: non_constant_identifier_names
 
+import 'package:json_annotation/json_annotation.dart';
+
+part 'score.g.dart';
+
+@JsonSerializable(explicitToJson: true)
 class Score {
   int mark; // 编号，用于某种计算，从 0 开始
   String name; // 学科名称
@@ -17,6 +22,7 @@ class Score {
   String? level; // 等级
   String? isPassedStr; //是否及格，null 没出分，1 通过 0 没有
   String? classID; // 教学班序列号
+
   Score({
     required this.mark,
     required this.name,
@@ -107,7 +113,42 @@ class Score {
         }
     }
   }
+
+  factory Score.fromJson(Map<String, dynamic> json) {
+    return Score(
+      mark: json['mark'],
+      name: json['name'],
+      score: (json['score'] as num?)?.toDouble(),
+      semesterCode: json['semesterCode'],
+      credit: (json['credit'] as num).toDouble(),
+      classStatus: json['classStatus'],
+      classType: json['classType'],
+      scoreStatus: json['scoreStatus'],
+      scoreTypeCode: json['scoreTypeCode'],
+      level: json['level'],
+      isPassedStr: json['isPassedStr'],
+      classID: json['classID'],
+    );
+  }
+
+  Map<String, dynamic> toJson() {
+    return {
+      'mark': mark,
+      'name': name,
+      'score': score,
+      'semesterCode': semesterCode,
+      'credit': credit,
+      'classStatus': classStatus,
+      'classType': classType,
+      'scoreStatus': scoreStatus,
+      'scoreTypeCode': scoreTypeCode,
+      'level': level,
+      'isPassedStr': isPassedStr,
+      'classID': classID,
+    };
+  }
 }
+
 
 class ComposeDetail {
   String content;

--- a/lib/model/xidian_ids/score.g.dart
+++ b/lib/model/xidian_ids/score.g.dart
@@ -1,0 +1,37 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+part of 'score.dart';
+
+// **************************************************************************
+// JsonSerializableGenerator
+// **************************************************************************
+
+Score _$ScoreFromJson(Map<String, dynamic> json) => Score(
+      mark: (json['mark'] as num).toInt(),
+      name: json['name'] as String,
+      score: (json['score'] as num?)?.toDouble(),
+      semesterCode: json['semesterCode'] as String,
+      credit: (json['credit'] as num).toDouble(),
+      classStatus: json['classStatus'] as String,
+      isPassedStr: json['isPassedStr'] as String?,
+      scoreTypeCode: (json['scoreTypeCode'] as num).toInt(),
+      classType: json['classType'] as String,
+      scoreStatus: json['scoreStatus'] as String,
+      level: json['level'] as String?,
+      classID: json['classID'] as String?,
+    );
+
+Map<String, dynamic> _$ScoreToJson(Score instance) => <String, dynamic>{
+      'mark': instance.mark,
+      'name': instance.name,
+      'score': instance.score,
+      'semesterCode': instance.semesterCode,
+      'credit': instance.credit,
+      'classStatus': instance.classStatus,
+      'classType': instance.classType,
+      'scoreStatus': instance.scoreStatus,
+      'scoreTypeCode': instance.scoreTypeCode,
+      'level': instance.level,
+      'isPassedStr': instance.isPassedStr,
+      'classID': instance.classID,
+    };

--- a/lib/page/score/score.dart
+++ b/lib/page/score/score.dart
@@ -6,6 +6,7 @@
 import 'package:flutter/material.dart';
 import 'package:watermeter/model/xidian_ids/score.dart';
 import 'package:watermeter/page/public_widget/public_widget.dart';
+import 'package:watermeter/page/public_widget/toast.dart';
 import 'package:watermeter/page/score/score_page.dart';
 import 'package:watermeter/page/score/score_state.dart';
 import 'package:watermeter/repository/xidian_ids/ehall_score_session.dart';
@@ -28,7 +29,16 @@ class _ScoreWindowState extends State<ScoreWindow> {
     );
   }
 
-  void dataInit() => scoreList = ScoreSession().getScore();
+  void dataInit() {
+    ScoreSession session = ScoreSession()
+    scoreList = session.getScore();
+    if (session.isScoreListCacheUsed) {
+      showToast(
+        context: context,
+        msg: "已显示缓存成绩信息",
+      );
+    }
+  }
 
   @override
   void initState() {

--- a/lib/page/setting/about_page/about_page.dart
+++ b/lib/page/setting/about_page/about_page.dart
@@ -63,6 +63,12 @@ class AboutPage extends StatelessWidget {
       "https://github.com/NanCunChild",
     ),
     Developer(
+      "Pairman",
+      "https://avatars.githubusercontent.com/u/18365163",
+      "开发：成绩信息缓存功能",
+      "https://github.com/ZCWzy",
+    ),
+    Developer(
       "ReverierXu",
       "https://blog.woooo.tech/img/avatar.png",
       "设计：用于信息展示的 ReX 卡片",


### PR DESCRIPTION
Scores will now be cached into ``scores.json`` for 6hrs, reducing network traffic and hence loading time. A toast will be displayed if cache is used. Fresh score fetching will only happen on fresh load or on previous error now.

Also a developer card for myself.