### PR TITLE
optimize ics output file size

### DIFF
--- a/lib/page/classtable/classtable_state.dart
+++ b/lib/page/classtable/classtable_state.dart
@@ -254,28 +254,62 @@ class ClassTableWidgetState with ChangeNotifier {
   /// Generate icalendar file string.
   String get iCalenderStr {
     String toReturn = "BEGIN:VCALENDAR\nTZID:Asia/Shanghai\n";
+
+    // @hgh: i here means each single course assignment
     for (var i in timeArrangement) {
       String summary =
           "SUMMARY:${getClassDetail(timeArrangement.indexOf(i))}@${i.classroom ?? "待定"}\n";
       String description =
           "DESCRIPTION:课程名称：${getClassDetail(timeArrangement.indexOf(i)).name}; "
           "上课地点：${i.classroom ?? "待定"}\n";
+
+      // @: j here means each week for a single course assignment
+      int j = 0;
+      // @: find the first week that has class
+      for(j = 0; !i.weekList[j]; ++j);
+
+      // @: initialize the first day(or, first recurrence) of the class
+      Jiffy day = Jiffy.parseFromDateTime(startDay).add(
+        weeks: j,
+        days: i.day - 1,
+      );
+      String vevent = "BEGIN:VEVENT\n$summary";
+      List<String> startTime = time[(i.start - 1) * 2].split(":");
+      List<String> stopTime = time[(i.stop - 1) * 2 + 1].split(":");        
+      vevent +=
+        "DTSTART:${day.add(hours: int.parse(startTime[0]), minutes: int.parse(startTime[1])).format(pattern: 'yyyyMMddTHHmmss')}\n";
+      vevent +=
+        "DTEND:${day.add(hours: int.parse(stopTime[0]), minutes: int.parse(stopTime[1])).format(pattern: 'yyyyMMddTHHmmss')}\n";
+      
       for (int j = 0; j < i.weekList.length; ++j) {
-        if (!i.weekList[j]) {
-          continue;
-        }
-        Jiffy day = Jiffy.parseFromDateTime(startDay).add(
-          weeks: j,
-          days: i.day - 1,
-        );
-        String vevent = "BEGIN:VEVENT\n$summary";
-        List<String> startTime = time[(i.start - 1) * 2].split(":");
-        List<String> stopTime = time[(i.stop - 1) * 2 + 1].split(":");
-        vevent +=
-            "DTSTART:${day.add(hours: int.parse(startTime[0]), minutes: int.parse(startTime[1])).format(pattern: 'yyyyMMddTHHmmss')}\n";
-        vevent +=
-            "DTEND:${day.add(hours: int.parse(stopTime[0]), minutes: int.parse(stopTime[1])).format(pattern: 'yyyyMMddTHHmmss')}\n";
-        toReturn += "$vevent${description}END:VEVENT\n";
+        // @: if the next week doesn't have class, then end the current recurrence
+        if (j != i.weekList.length - 1 && !i.weekList[j + 1]) {
+            vevent += "RRULE:FREQ=WEEKLY;UNTIL=${day.add(weeks: j).set(hour:23, minute:59, second:59).format(pattern: 'yyyyMMddTHHmmss')}\n";
+            toReturn += "$vevent${description}END:VEVENT\n";// one recurrence over equals to one VEVENT over
+
+            /*
+            *  upper: end the current recurrence
+            *
+            *  lower: start a new recurrence
+            */
+            
+            // @: find the next week that has class
+            j++;
+            while(j < i.weekList.length && !i.weekList[j]) ++j;
+            // @: if the next week is the last week, then end the current recurrence
+            if(j == i.weekList.length) break;
+
+            // reset the vevent
+            Jiffy day = Jiffy.parseFromDateTime(startDay).add(
+              weeks: j,
+              days: i.day - 1,
+            );
+            vevent = "BEGIN:VEVENT\n$summary";   
+            vevent +=
+              "DTSTART:${day.add(weeks: j, hours: int.parse(startTime[0]), minutes: int.parse(startTime[1])).format(pattern: 'yyyyMMddTHHmmss')}\n";
+            vevent +=
+              "DTEND:${day.add(weeks: j, hours: int.parse(stopTime[0]), minutes: int.parse(stopTime[1])).format(pattern: 'yyyyMMddTHHmmss')}\n";            
+        } 
       }
     }
     return "${toReturn}END:VCALENDAR";


### PR DESCRIPTION
# Definition

同一课程名 同一上课节次(e.g.1-2节) 每一周的同一天 视为`my_course`（即259行遍历`timeArrangement`的`i`）

# 优化思路

由于原来的导出文件是把每门课程每一次上课都记为一个`VEVENT`，这样相对臃肿，基于ics的[recurrence rule](https://icalendar.org/iCalendar-RFC-5545/3-8-5-3-recurrence-rule.html)，可以将定期发生（在课程表的情况下就是每周发生）的事件统一记为一个`VEVENT`. 即每个`my_course`都可以记为1个或若干个含有`RRULE`的`VEVENT`

# 考虑到如下情况：

学期中间有清明节调课，《初级英语》的课程安排变成了 周三12节(1-8周，10-16周）
因为这两个分段是在一个i的，只要记为两个`VEVENT`，第一个`VEVENT`中: {`DTSTART`和`DTEND`设为1周周三的上课时间(2025.2.19 8:30-10:05) `UNTIL`设为8周周三的23:59:59} 第二个`VEVENT`中: {`DTSTART`和`DTEND`设为10周周三的上课时间(2025.4.23 8:30-10:05) `UNTIL`设为16周周三的23:59:59} 

# 为什么`23:59:59` (Line: 287)

因为UNTIL是时间发生的截止时间，因为我担心冲突，所以设置为23:59:59，那么，在当天的23:59:59之前的课都可以发生
