### PR TITLE
feat: add FIDO WebAuthn login support

### DIFF
--- a/assets/flutter_i18n/en_US.yaml
+++ b/assets/flutter_i18n/en_US.yaml
@@ -661,6 +661,10 @@ login:
       hint: "Input captcha"
       message_on_empty: "Please enter captcha"
    slider_title: "Server authentication service"
+   fido_quick_login: "FIDO Quick Login"
+   fido_login_progress: "Logging in with FIDO..."
+   fido_login_failed: "FIDO login failed: {message}"
+   fido_login_fallback: "FIDO login failed, please use password login"
 
 # 校园网信息
 school_net:
@@ -810,6 +814,29 @@ setting:
    electricity_account_setting: "Electricity account setting"
    schoolnet_password_setting: "Campus net password"
    schoolnet_password_description: "If you have not setted it, you cannot query it."
+   # FIDO Quick Login
+   fido_setting: "FIDO Quick Login"
+   fido_registered: "Registered"
+   fido_not_registered: "Not registered"
+   fido_login_required: "Please log in first"
+   fido_register_success: "FIDO registration successful"
+   fido_register_failed: "FIDO registration failed: {error}"
+   fido_delete_title: "Delete FIDO Credential"
+   fido_delete_content: "Are you sure you want to delete the FIDO credential? You will need to re-register to use FIDO login."
+   fido_delete_success: "FIDO credential deleted"
+   fido_delete_failed: "FIDO deletion failed: {error}"
+   fido_prompt_title: "Enable FIDO Quick Login?"
+   fido_prompt_content: |-
+      FIDO is an alternative login method for when password login has issues.
+
+      · No captcha needed: bypasses slider and image captcha verification
+      · Backup login: works normally when password login encounters problems
+      · Device-based authentication: uses device key pair instead of password
+   fido_prompt_register: "Register Now"
+   fido_prompt_skip: "Maybe Later"
+   fido_prompt_registering: "Registering FIDO..."
+   fido_prompt_success: "FIDO registered! You can use quick login next time"
+   fido_prompt_failed: "FIDO registration failed: {error}"
    # 通知设置
    notification_setting: "Notification Settings"
    course_reminder_setting: "Pre-class Reminder Settings"

--- a/assets/flutter_i18n/en_US.yaml
+++ b/assets/flutter_i18n/en_US.yaml
@@ -42,6 +42,17 @@ login_process:
    slider: "Solving slider captcha"
    after_process: "Post-login processing"
    failed: "Login failed, response status code: {statusCode}"
+   image_captcha:
+      title: "Enter Captcha"
+      refresh_hint: "Tap image to refresh"
+      hint: "Enter captcha"
+      confirm: "Confirm"
+fido_process:
+   prepare: "Preparing FIDO login"
+   start_assertion: "Requesting assertion"
+   signing: "Signing"
+   submitting: "Submitting"
+   done: "Login complete"
 # TODO: ehall_exam_session data
 
 no_info: "No information"
@@ -1041,6 +1052,7 @@ setting:
       english: "English"
    semester_change: Change semester
    semester_change_description: Using semester {semester}
+   updating_data: "Updating data"
    semester_update_data: "Applying new semester setting"
    # 关于页面
    easter_egg_page: "You found an Easter egg"

--- a/assets/flutter_i18n/zh_CN.yaml
+++ b/assets/flutter_i18n/zh_CN.yaml
@@ -36,6 +36,17 @@ login_process:
     slider: "滑块验证"
     after_process: "登录后处理"
     failed: "登录失败，响应状态码：{statusCode}"
+    image_captcha:
+        title: "输入验证码"
+        refresh_hint: "点击图片刷新"
+        hint: "输入验证码"
+        confirm: "确认"
+fido_process:
+    prepare: "准备 FIDO 登录"
+    start_assertion: "获取认证请求"
+    signing: "签名中"
+    submitting: "提交认证"
+    done: "登录完成"
 # TODO: ehall_exam_session data
 
 no_info: "没有信息"
@@ -991,6 +1002,7 @@ setting:
         english: "英语"
     semester_change: 修改学期
     semester_change_description: 使用学期 {semester}
+    updating_data: "正在更新数据"
     semester_update_data: "应用新学期设置中"
     # 关于页面
     easter_egg_page: "你找到了彩蛋"

--- a/assets/flutter_i18n/zh_CN.yaml
+++ b/assets/flutter_i18n/zh_CN.yaml
@@ -623,6 +623,10 @@ login:
         hint: "输入验证码"
         message_on_empty: "请输入验证码"
     slider_title: "服务器认证服务"
+    fido_quick_login: "FIDO 快速登录"
+    fido_login_progress: "FIDO 登录中..."
+    fido_login_failed: "FIDO 登录失败: {message}"
+    fido_login_fallback: "FIDO 登录失败，请使用密码登录"
 
 # 校园网信息
 school_net:
@@ -769,6 +773,29 @@ setting:
     electricity_account_setting: "电费账号设置"
     schoolnet_password_setting: "校园网帐号密码设置"
     schoolnet_password_description: "不设置查看不了网费"
+    # FIDO 快速登录
+    fido_setting: "FIDO 快速登录"
+    fido_registered: "已注册"
+    fido_not_registered: "未注册"
+    fido_login_required: "请先登录"
+    fido_register_success: "FIDO 注册成功"
+    fido_register_failed: "FIDO 注册失败: {error}"
+    fido_delete_title: "删除 FIDO 凭据"
+    fido_delete_content: "确定要删除 FIDO 凭据吗？删除后需重新注册才能使用 FIDO 登录。"
+    fido_delete_success: "FIDO 凭据已删除"
+    fido_delete_failed: "FIDO 删除失败: {error}"
+    fido_prompt_title: "启用 FIDO 快速登录？"
+    fido_prompt_content: |-
+        FIDO 是一种备用登录方式，在密码登录遇到问题时可以使用。
+
+        · 不受验证码影响：无需处理滑块验证和图片验证码
+        · 备用登录方式：当密码登录异常时仍可正常登录
+        · 基于设备认证：使用设备密钥对验证身份，不依赖密码
+    fido_prompt_register: "立即注册"
+    fido_prompt_skip: "以后再说"
+    fido_prompt_registering: "正在注册 FIDO..."
+    fido_prompt_success: "FIDO 注册成功！下次可使用快速登录"
+    fido_prompt_failed: "FIDO 注册失败: {error}"
     # 通知设置
     notification_setting: "通知设置"
     course_reminder_setting: "课前通知设置"

--- a/assets/flutter_i18n/zh_TW.yaml
+++ b/assets/flutter_i18n/zh_TW.yaml
@@ -579,6 +579,10 @@ login:
     hint: 輸入驗證碼
     message_on_empty: 請輸入驗證碼
   slider_title: 服務器認證服務
+  fido_quick_login: FIDO 快速登錄
+  fido_login_progress: FIDO 登錄中...
+  fido_login_failed: 'FIDO 登錄失敗: {message}'
+  fido_login_fallback: FIDO 登錄失敗，請使用密碼登錄
 school_net:
   title: 校園網使用詳情
   ids_account_net:
@@ -715,6 +719,29 @@ setting:
   electricity_account_setting: 電費賬號設置
   schoolnet_password_setting: 校園網帳號密碼設置
   schoolnet_password_description: 不設置查看不了網費
+  # FIDO 快速登錄
+  fido_setting: FIDO 快速登錄
+  fido_registered: 已註冊
+  fido_not_registered: 未註冊
+  fido_login_required: 請先登錄
+  fido_register_success: FIDO 註冊成功
+  fido_register_failed: 'FIDO 註冊失敗: {error}'
+  fido_delete_title: 刪除 FIDO 憑據
+  fido_delete_content: 確定要刪除 FIDO 憑據嗎？刪除後需重新註冊才能使用 FIDO 登錄。
+  fido_delete_success: FIDO 憑據已刪除
+  fido_delete_failed: 'FIDO 刪除失敗: {error}'
+  fido_prompt_title: 啟用 FIDO 快速登錄？
+  fido_prompt_content: |-
+    FIDO 是一種備用登錄方式，在密碼登錄遇到問題時可以使用。
+
+    · 不受驗證碼影響：無需處理滑塊驗證和圖片驗證碼
+    · 備用登錄方式：當密碼登錄異常時仍可正常登錄
+    · 基於設備認證：使用設備密鑰對驗證身份，不依賴密碼
+  fido_prompt_register: 立即註冊
+  fido_prompt_skip: 以後再說
+  fido_prompt_registering: 正在註冊 FIDO...
+  fido_prompt_success: FIDO 註冊成功！下次可使用快速登錄
+  fido_prompt_failed: 'FIDO 註冊失敗: {error}'
   notification_setting: 通知設置
   course_reminder_setting: 課前通知設置
   course_reminder_description: 設置課前提醒通知

--- a/assets/flutter_i18n/zh_TW.yaml
+++ b/assets/flutter_i18n/zh_TW.yaml
@@ -26,6 +26,17 @@ login_process:
   slider: 滑塊驗證
   after_process: 登錄後處理
   failed: 登錄失敗，響應狀態碼：{statusCode}
+  image_captcha:
+    title: 輸入驗證碼
+    refresh_hint: 點擊圖片刷新
+    hint: 輸入驗證碼
+    confirm: 確認
+fido_process:
+  prepare: 準備 FIDO 登錄
+  start_assertion: 獲取認證請求
+  signing: 簽名中
+  submitting: 提交認證
+  done: 登錄完成
 no_info: 沒有信息
 catcher_detected: 發生錯誤
 catcher_description: 詳情如下
@@ -930,6 +941,7 @@ setting:
     english: 英語
   semester_change: 修改學期
   semester_change_description: 使用學期 {semester}
+  updating_data: 正在更新數據
   semester_update_data: 應用新學期設置中
   easter_egg_page: 你找到了彩蛋
   about_page:

--- a/lib/page/login/image_captcha.dart
+++ b/lib/page/login/image_captcha.dart
@@ -1,0 +1,130 @@
+// Copyright 2025 Traintime PDA authors.
+// SPDX-License-Identifier: MPL-2.0
+
+// Image captcha widget for IDS recheck (二次验证).
+// Follows the same pattern as CaptchaWidget: StatefulWidget + Navigator.pop.
+//
+// The widget receives a captcha image and a fetch callback.
+// It pops the user-entered captcha code on submit, or null on cancel.
+
+import 'dart:typed_data';
+
+import 'package:flutter/material.dart';
+
+/// Callback to fetch a new captcha image.
+/// Returns the image bytes.
+typedef CaptchaFetchCallback = Future<Uint8List> Function();
+
+class ImageCaptchaWidget extends StatefulWidget {
+  final Uint8List initialImage;
+  final CaptchaFetchCallback onRefresh;
+
+  const ImageCaptchaWidget({
+    super.key,
+    required this.initialImage,
+    required this.onRefresh,
+  });
+
+  @override
+  State<ImageCaptchaWidget> createState() => _ImageCaptchaWidgetState();
+}
+
+class _ImageCaptchaWidgetState extends State<ImageCaptchaWidget> {
+  final _controller = TextEditingController();
+  Uint8List? _imageData;
+  bool _loading = false;
+
+  @override
+  void initState() {
+    super.initState();
+    _imageData = widget.initialImage;
+  }
+
+  @override
+  void dispose() {
+    _controller.dispose();
+    super.dispose();
+  }
+
+  Future<void> _refresh() async {
+    setState(() => _loading = true);
+    try {
+      final image = await widget.onRefresh();
+      if (mounted) {
+        setState(() {
+          _imageData = image;
+          _controller.clear();
+          _loading = false;
+        });
+      }
+    } catch (e) {
+      if (mounted) {
+        setState(() => _loading = false);
+      }
+    }
+  }
+
+  void _submit() {
+    final code = _controller.text.trim();
+    if (code.isNotEmpty) {
+      Navigator.of(context).pop(code);
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(
+        title: const Text("输入验证码"),
+      ),
+      body: Center(
+        child: Column(
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            GestureDetector(
+              onTap: _loading ? null : _refresh,
+              child: _imageData != null
+                  ? Image.memory(
+                      _imageData!,
+                      width: 200,
+                      fit: BoxFit.fitWidth,
+                    )
+                  : const SizedBox(
+                      width: 200,
+                      height: 80,
+                      child: Center(child: CircularProgressIndicator()),
+                    ),
+            ),
+            const SizedBox(height: 4),
+            Text(
+              "点击图片刷新",
+              style: TextStyle(
+                fontSize: 12,
+                color: Theme.of(context).colorScheme.outline,
+              ),
+            ),
+            const SizedBox(height: 16),
+            SizedBox(
+              width: 200,
+              child: TextField(
+                controller: _controller,
+                textAlign: TextAlign.center,
+                maxLength: 4,
+                decoration: const InputDecoration(
+                  hintText: "输入验证码",
+                  counterText: "",
+                ),
+                onSubmitted: (_) => _submit(),
+              ),
+            ),
+            const SizedBox(height: 16),
+            FilledButton(
+              onPressed: _loading ? null : _submit,
+              child: const Text("确认"),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/lib/page/login/image_captcha.dart
+++ b/lib/page/login/image_captcha.dart
@@ -10,6 +10,7 @@
 import 'dart:typed_data';
 
 import 'package:flutter/material.dart';
+import 'package:flutter_i18n/flutter_i18n.dart';
 
 /// Callback to fetch a new captcha image.
 /// Returns the image bytes.
@@ -75,7 +76,7 @@ class _ImageCaptchaWidgetState extends State<ImageCaptchaWidget> {
   Widget build(BuildContext context) {
     return Scaffold(
       appBar: AppBar(
-        title: const Text("输入验证码"),
+        title: Text(FlutterI18n.translate(context, "login.image_captcha.title")),
       ),
       body: Center(
         child: Column(
@@ -97,7 +98,7 @@ class _ImageCaptchaWidgetState extends State<ImageCaptchaWidget> {
             ),
             const SizedBox(height: 4),
             Text(
-              "点击图片刷新",
+              FlutterI18n.translate(context, "login.image_captcha.refresh_hint"),
               style: TextStyle(
                 fontSize: 12,
                 color: Theme.of(context).colorScheme.outline,
@@ -110,8 +111,8 @@ class _ImageCaptchaWidgetState extends State<ImageCaptchaWidget> {
                 controller: _controller,
                 textAlign: TextAlign.center,
                 maxLength: 4,
-                decoration: const InputDecoration(
-                  hintText: "输入验证码",
+                decoration: InputDecoration(
+                  hintText: FlutterI18n.translate(context, "login.image_captcha.hint"),
                   counterText: "",
                 ),
                 onSubmitted: (_) => _submit(),
@@ -120,7 +121,7 @@ class _ImageCaptchaWidgetState extends State<ImageCaptchaWidget> {
             const SizedBox(height: 16),
             FilledButton(
               onPressed: _loading ? null : _submit,
-              child: const Text("确认"),
+              child: Text(FlutterI18n.translate(context, "login.image_captcha.confirm")),
             ),
           ],
         ),

--- a/lib/page/login/jc_captcha.dart
+++ b/lib/page/login/jc_captcha.dart
@@ -15,6 +15,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter_i18n/flutter_i18n.dart';
 import 'package:styled_widget/styled_widget.dart';
 import 'package:watermeter/repository/logger.dart';
+import 'package:watermeter/repository/xidian_ids/ids_crypto.dart';
 
 class Lazy<T> {
   final T Function() _initializer;
@@ -76,8 +77,10 @@ class SliderCaptchaClientProvider {
     return encrypted.base64;
   }
 
+
   /// 解密逻辑
   static String decryptData(String cipherText, Uint8List keyBytes) {
+    const blockSize = 16;
     final Uint8List fullCipher = base64.decode(cipherText);
 
     if (fullCipher.length < _blockSize * 4) {
@@ -252,27 +255,12 @@ class SliderCaptchaClientProvider {
   }
 
   String _encryptPayload(String payload) {
-    if (pieceData == null || pieceData!.length < _captchaKeySize) {
+    if (pieceData == null || pieceData!.length < _keySize) {
       throw StateError("Captcha image is too short to contain AES key.");
     }
 
-    final keyBytes = pieceData!.sublist(pieceData!.length - _captchaKeySize);
-    final key = encrypt.Key(Uint8List.fromList(keyBytes));
-    final iv = encrypt.IV.fromUtf8(_randomString(_blockSize));
-    final nonce = _randomString(_blockSize * 4);
-    final aes = encrypt.Encrypter(encrypt.AES(key, mode: encrypt.AESMode.cbc));
-
-    final plain = "$nonce$payload";
-    return aes.encrypt(plain, iv: iv).base64;
-  }
-
-  static String _randomString(int length) {
-    return String.fromCharCodes(
-      List.generate(
-        length,
-        (_) => _aesChars.codeUnitAt(_random.nextInt(_aesChars.length)),
-      ),
-    );
+    final keyBytes = pieceData!.sublist(pieceData!.length - _keySize);
+    return IdsCrypto.encryptPassword(payload, Uint8List.fromList(keyBytes));
   }
 }
 

--- a/lib/page/login/jc_captcha.dart
+++ b/lib/page/login/jc_captcha.dart
@@ -15,7 +15,6 @@ import 'package:flutter/material.dart';
 import 'package:flutter_i18n/flutter_i18n.dart';
 import 'package:styled_widget/styled_widget.dart';
 import 'package:watermeter/repository/logger.dart';
-import 'package:watermeter/repository/xidian_ids/ids_crypto.dart';
 
 class Lazy<T> {
   final T Function() _initializer;
@@ -77,10 +76,8 @@ class SliderCaptchaClientProvider {
     return encrypted.base64;
   }
 
-
   /// 解密逻辑
   static String decryptData(String cipherText, Uint8List keyBytes) {
-    const blockSize = 16;
     final Uint8List fullCipher = base64.decode(cipherText);
 
     if (fullCipher.length < _blockSize * 4) {
@@ -255,12 +252,27 @@ class SliderCaptchaClientProvider {
   }
 
   String _encryptPayload(String payload) {
-    if (pieceData == null || pieceData!.length < _keySize) {
+    if (pieceData == null || pieceData!.length < _captchaKeySize) {
       throw StateError("Captcha image is too short to contain AES key.");
     }
 
-    final keyBytes = pieceData!.sublist(pieceData!.length - _keySize);
-    return IdsCrypto.encryptPassword(payload, Uint8List.fromList(keyBytes));
+    final keyBytes = pieceData!.sublist(pieceData!.length - _captchaKeySize);
+    final key = encrypt.Key(Uint8List.fromList(keyBytes));
+    final iv = encrypt.IV.fromUtf8(_randomString(_blockSize));
+    final nonce = _randomString(_blockSize * 4);
+    final aes = encrypt.Encrypter(encrypt.AES(key, mode: encrypt.AESMode.cbc));
+
+    final plain = "$nonce$payload";
+    return aes.encrypt(plain, iv: iv).base64;
+  }
+
+  static String _randomString(int length) {
+    return String.fromCharCodes(
+      List.generate(
+        length,
+        (_) => _aesChars.codeUnitAt(_random.nextInt(_aesChars.length)),
+      ),
+    );
   }
 }
 

--- a/lib/page/login/login_window.dart
+++ b/lib/page/login/login_window.dart
@@ -4,6 +4,7 @@
 
 // Login window of the program.
 
+import 'dart:io';
 import 'dart:math';
 import 'package:dio/dio.dart';
 import 'package:flutter/material.dart';
@@ -20,6 +21,8 @@ import 'package:watermeter/repository/xidian_ids/ehall_session.dart';
 import 'package:watermeter/repository/preference.dart' as preference;
 import 'package:watermeter/page/homepage/home.dart';
 import 'package:watermeter/repository/xidian_ids/ids_session.dart';
+import 'package:watermeter/repository/xidian_ids/fido_session.dart';
+import 'package:watermeter/repository/xidian_ids/ids_recheck.dart';
 import 'package:watermeter/page/login/bottom_buttons.dart';
 import 'package:watermeter/repository/xidian_ids/personal_info_session.dart';
 
@@ -104,6 +107,18 @@ class _LoginWindowState extends State<LoginWindow> {
           }
         },
       ),
+      if (preference.getBool(preference.Preference.fidoEnabled)) ...[
+        const SizedBox(height: 8.0),
+        OutlinedButton(
+          style: OutlinedButton.styleFrom(
+            minimumSize: const Size(double.infinity, 48),
+          ),
+          child: Text(FlutterI18n.translate(context, "login.fido_quick_login")),
+          onPressed: () async {
+            await _fidoLogin();
+          },
+        ),
+      ],
       const SizedBox(height: 8.0),
       const ButtomButtons(),
     ],
@@ -170,9 +185,17 @@ class _LoginWindowState extends State<LoginWindow> {
 
         if (mounted) {
           if (pd.isOpen()) pd.close();
-          Navigator.of(context).pushReplacement(
-            MaterialPageRoute(builder: (context) => const HomePage()),
-          );
+
+          // Prompt FIDO registration if not yet enabled
+          if (!preference.getBool(preference.Preference.fidoEnabled)) {
+            await _promptFidoRegister();
+          }
+
+          if (mounted) {
+            Navigator.of(context).pushReplacement(
+              MaterialPageRoute(builder: (context) => const HomePage()),
+            );
+          }
         }
       }
     } catch (e, s) {
@@ -232,6 +255,165 @@ class _LoginWindowState extends State<LoginWindow> {
             msg: FlutterI18n.translate(context, "login.failed_login_other"),
           );
         }
+      }
+    }
+  }
+
+  Future<void> _fidoLogin() async {
+    ProgressDialog pd = ProgressDialog(context: context);
+    pd.show(
+      msg: FlutterI18n.translate(context, "login.fido_login_progress"),
+      max: 100,
+      hideValue: true,
+      completed: Completed(
+        completedMsg: FlutterI18n.translate(context, "login.complete_login"),
+      ),
+    );
+
+    try {
+      EhallSession ses = EhallSession();
+      await ses.clearCookieJar();
+
+      FidoSession fido = FidoSession();
+      String location = await fido.fidoLogin(
+        target:
+            "https://ehall.xidian.edu.cn:443/login?service=https://ehall.xidian.edu.cn/new/index.html",
+        onResponse: (int number, String status) => pd.update(
+          msg: status,
+          value: number,
+        ),
+      );
+
+      // Follow redirects
+      var response = await fido.dioNoOfflineCheck.get(location);
+      while (response.headers[HttpHeaders.locationHeader] != null) {
+        location = response.headers[HttpHeaders.locationHeader]![0];
+        response = await ses.dioEhall.get(location);
+      }
+
+      loginState = IDSLoginState.success;
+
+      if (!mounted) return;
+      preference.setString(
+        preference.Preference.idsAccount,
+        _idsAccountController.text,
+      );
+
+      bool isPostGraduate = await ses.checkWhetherPostgraduate();
+      String semesterInfo = isPostGraduate
+          ? await PersonalInfoSession().getSemesterInfoYjspt()
+          : await PersonalInfoSession().getSemesterInfoEhall();
+      preference.setString(
+        preference.Preference.currentSemester,
+        semesterInfo,
+      );
+      preference.setBool(preference.Preference.isUserDefinedSemester, false);
+
+      if (mounted) {
+        if (pd.isOpen()) pd.close();
+        Navigator.of(context).pushReplacement(
+          MaterialPageRoute(builder: (context) => const HomePage()),
+        );
+      }
+    } catch (e, s) {
+      if (pd.isOpen()) pd.close();
+      log.warning(
+        "[login_window][fidoLogin] "
+        "FIDO login failed: \n$e\nStacktrace is:\n$s",
+      );
+      if (mounted) {
+        if (e is FidoException) {
+          showToast(
+            context: context,
+            msg: FlutterI18n.translate(
+              context,
+              "login.fido_login_failed",
+              translationParams: {"message": e.msg},
+            ),
+          );
+        } else if (e is LoginFailedException) {
+          showToast(context: context, msg: e.msg);
+        } else {
+          showToast(
+            context: context,
+            msg: FlutterI18n.translate(context, "login.fido_login_fallback"),
+          );
+        }
+      }
+    }
+  }
+
+  Future<void> _promptFidoRegister() async {
+    if (!context.mounted) return;
+    final agree = await showDialog<bool>(
+      context: context,
+      builder: (context) => AlertDialog(
+        title: Text(
+          FlutterI18n.translate(context, "setting.fido_prompt_title"),
+        ),
+        content: Text(
+          FlutterI18n.translate(context, "setting.fido_prompt_content"),
+        ),
+        actions: [
+          TextButton(
+            onPressed: () => Navigator.pop(context, false),
+            child: Text(
+              FlutterI18n.translate(context, "setting.fido_prompt_skip"),
+            ),
+          ),
+          TextButton(
+            onPressed: () => Navigator.pop(context, true),
+            child: Text(
+              FlutterI18n.translate(context, "setting.fido_prompt_register"),
+            ),
+          ),
+        ],
+      ),
+    );
+
+    if (agree != true || !context.mounted) return;
+
+    ProgressDialog pd = ProgressDialog(context: context);
+    pd.show(
+      msg: FlutterI18n.translate(context, "setting.fido_prompt_registering"),
+      hideValue: true,
+    );
+
+    try {
+      final recheck = IdsRecheck();
+      await recheck.ensurePersonalInfoSession();
+
+      final necessary = await recheck.isNecessary();
+      if (necessary && context.mounted) {
+        await recheck.recheckByPassword(
+          context: context,
+          password: _idsPasswordController.text,
+        );
+      }
+
+      if (!context.mounted) return;
+      final fido = FidoSession();
+      await fido.register(context: context);
+
+      if (pd.isOpen()) pd.close();
+      if (context.mounted) {
+        showToast(
+          context: context,
+          msg: FlutterI18n.translate(context, "setting.fido_prompt_success"),
+        );
+      }
+    } catch (e) {
+      if (pd.isOpen()) pd.close();
+      log.warning("[login_window] FIDO prompt registration failed: $e");
+      if (context.mounted) {
+        showToast(
+          context: context,
+          msg: FlutterI18n.translate(
+            context,
+            "setting.fido_prompt_failed",
+            translationParams: {"error": e.toString()},
+          ),
+        );
       }
     }
   }

--- a/lib/page/login/login_window.dart
+++ b/lib/page/login/login_window.dart
@@ -294,11 +294,6 @@ class _LoginWindowState extends State<LoginWindow> {
       loginState = IDSLoginState.success;
 
       if (!mounted) return;
-      preference.setString(
-        preference.Preference.idsAccount,
-        _idsAccountController.text,
-      );
-
       bool isPostGraduate = await ses.checkWhetherPostgraduate();
       String semesterInfo = isPostGraduate
           ? await PersonalInfoSession().getSemesterInfoYjspt()

--- a/lib/page/login/login_window.dart
+++ b/lib/page/login/login_window.dart
@@ -279,7 +279,7 @@ class _LoginWindowState extends State<LoginWindow> {
         target:
             "https://ehall.xidian.edu.cn:443/login?service=https://ehall.xidian.edu.cn/new/index.html",
         onResponse: (int number, String status) => pd.update(
-          msg: status,
+          msg: FlutterI18n.translate(context, status),
           value: number,
         ),
       );

--- a/lib/page/setting/setting.dart
+++ b/lib/page/setting/setting.dart
@@ -46,6 +46,9 @@ import 'package:watermeter/repository/network_session.dart';
 import 'package:watermeter/repository/user_defined_class_file.dart';
 import 'package:watermeter/repository/xidian_ids/classtable_session.dart';
 import 'package:watermeter/repository/xidian_ids/energy_session.dart';
+import 'package:watermeter/repository/xidian_ids/fido_session.dart';
+import 'package:watermeter/repository/xidian_ids/ids_recheck.dart';
+import 'package:watermeter/repository/xidian_ids/ids_session.dart';
 import 'package:watermeter/repository/xidian_ids/exam_session.dart';
 import 'package:watermeter/repository/xidian_ids/score_session.dart';
 import 'package:watermeter/repository/xidian_ids/sysj_session.dart';
@@ -99,6 +102,153 @@ class _SettingWindowState extends State<SettingWindow> {
     while (_isSemesterAwareControllerLoading &&
         stopwatch.elapsed < const Duration(seconds: 30)) {
       await Future<void>.delayed(const Duration(milliseconds: 100));
+    }
+  }
+
+  Future<void> _registerFido() async {
+    if (offline) {
+      if (!context.mounted) return;
+      showToast(
+        context: context,
+        msg: FlutterI18n.translate(context, "setting.fido_login_required"),
+      );
+      return;
+    }
+
+    try {
+      final recheck = IdsRecheck();
+
+      // Ensure authenticated session for /personalInfo service
+      await recheck.ensurePersonalInfoSession();
+
+      final necessary = await recheck.isNecessary();
+
+      if (necessary) {
+        if (!context.mounted) return;
+        await recheck.recheckByPassword(
+          context: context,
+          password: preference.getString(preference.Preference.idsPassword),
+        );
+      }
+
+      if (!context.mounted) return;
+
+      final fido = FidoSession();
+      await fido.register(context: context);
+
+      if (!context.mounted) return;
+      setState(() {});
+      showToast(
+        context: context,
+        msg: FlutterI18n.translate(context, "setting.fido_register_success"),
+      );
+    } catch (e) {
+      log.warning("[setting] FIDO registration failed: $e");
+      if (!context.mounted) return;
+      showToast(
+        context: context,
+        msg: FlutterI18n.translate(
+          context,
+          "setting.fido_register_failed",
+          translationParams: {"error": e.toString()},
+        ),
+      );
+    }
+  }
+
+  Future<void> _deleteFido() async {
+    final confirm = await showDialog<bool>(
+      context: context,
+      builder: (context) => AlertDialog(
+        title: Text(FlutterI18n.translate(context, "setting.fido_delete_title")),
+        content: Text(FlutterI18n.translate(context, "setting.fido_delete_content")),
+        actions: [
+          TextButton(
+            onPressed: () => Navigator.pop(context, false),
+            child: Text(FlutterI18n.translate(context, "cancel")),
+          ),
+          TextButton(
+            onPressed: () => Navigator.pop(context, true),
+            child: Text(FlutterI18n.translate(context, "confirm")),
+          ),
+        ],
+      ),
+    );
+
+    if (confirm != true) return;
+
+    try {
+      // 1. Ensure authenticated session + recheck
+      final recheck = IdsRecheck();
+      await recheck.ensurePersonalInfoSession();
+      final necessary = await recheck.isNecessary();
+
+      if (necessary) {
+        if (!context.mounted) return;
+        await recheck.recheckByPassword(
+          context: context,
+          password: preference.getString(preference.Preference.idsPassword),
+        );
+      }
+
+      // 2. Server-side delete
+      // The deleteDevice endpoint expects the student ID (username) as 'response',
+      // not the userHandle.
+      final credentialId =
+          preference.getString(preference.Preference.fidoCredentialId);
+      final username =
+          preference.getString(preference.Preference.idsAccount);
+
+      await recheck.deleteDevice(
+        credentialId: credentialId,
+        username: username,
+      );
+
+      // 3. Clear local credentials
+      await preference.remove(preference.Preference.fidoCredentialId);
+      await preference.remove(preference.Preference.fidoPrivateKeyPem);
+      await preference.remove(preference.Preference.fidoUserHandle);
+      await preference.remove(preference.Preference.fidoAnonbiometricsd);
+      await preference.setBool(preference.Preference.fidoEnabled, false);
+
+      if (!context.mounted) return;
+      setState(() {});
+      showToast(
+        context: context,
+        msg: FlutterI18n.translate(context, "setting.fido_delete_success"),
+      );
+    } catch (e) {
+      log.warning("[setting] FIDO deletion failed: $e");
+      if (!context.mounted) return;
+      showToast(
+        context: context,
+        msg: FlutterI18n.translate(
+          context,
+          "setting.fido_delete_failed",
+          translationParams: {"error": e.toString()},
+        ),
+      );
+    }
+  }
+
+  /// Try to delete FIDO credential from server before clearing local data.
+  /// Silently ignores errors since we're clearing data anyway.
+  Future<void> _tryDeleteFido() async {
+    if (!preference.getBool(preference.Preference.fidoEnabled)) return;
+    try {
+      final recheck = IdsRecheck();
+      await recheck.ensurePersonalInfoSession();
+      final credentialId =
+          preference.getString(preference.Preference.fidoCredentialId);
+      final username =
+          preference.getString(preference.Preference.idsAccount);
+      await recheck.deleteDevice(
+        credentialId: credentialId,
+        username: username,
+      );
+      log.info("[setting] FIDO credential deleted from server before logout.");
+    } catch (e) {
+      log.warning("[setting] Failed to delete FIDO from server (continuing): $e");
     }
   }
 
@@ -427,6 +577,23 @@ class _SettingWindowState extends State<SettingWindow> {
                   ),
                   const Divider(),
                 ],
+                ListTile(
+                  title: Text(FlutterI18n.translate(context, "setting.fido_setting")),
+                  subtitle: Text(
+                    preference.getBool(preference.Preference.fidoEnabled)
+                        ? FlutterI18n.translate(context, "setting.fido_registered")
+                        : FlutterI18n.translate(context, "setting.fido_not_registered"),
+                  ),
+                  trailing: preference.getBool(preference.Preference.fidoEnabled)
+                      ? IconButton(
+                          icon: const Icon(Icons.delete_outline),
+                          onPressed: () => _deleteFido(),
+                        )
+                      : const Icon(Icons.navigate_next),
+                  onTap: preference.getBool(preference.Preference.fidoEnabled)
+                      ? null
+                      : () => _registerFido(),
+                ),
                 /*
                 ListTile(
                   title: Text(
@@ -831,6 +998,7 @@ class _SettingWindowState extends State<SettingWindow> {
                                 "setting.clear_and_restart_dialog.cleaning",
                               ),
                             );
+                            await _tryDeleteFido();
                             try {
                               await NetworkSession().clearCookieJar();
                             } on PathNotFoundException {
@@ -904,6 +1072,9 @@ class _SettingWindowState extends State<SettingWindow> {
                                 "setting.logout_dialog.logging_out",
                               ),
                             );
+
+                            /// Delete FIDO from server before clearing cookies
+                            await _tryDeleteFido();
 
                             /// Clean Cookie
                             try {

--- a/lib/page/setting/setting.dart
+++ b/lib/page/setting/setting.dart
@@ -913,7 +913,10 @@ class _SettingWindowState extends State<SettingWindow> {
                       if (value == true) {
                         setState(() {});
                         if (context.mounted) {
-                          showToast(context: context, msg: "Updating data");
+                          showToast(
+                            context: context,
+                            msg: FlutterI18n.translate(context, "setting.updating_data"),
+                          );
                         }
                         await _waitForSemesterAwareReloads();
                         await maybeAutoSyncSystemCalendar();

--- a/lib/repository/preference.dart
+++ b/lib/repository/preference.dart
@@ -142,7 +142,12 @@ enum Preference {
   classStyleCompletedInnerAlpha(
     key: "classStyleCompletedInnerAlpha",
     type: "double",
-  ); // 已完成课程底色透明度
+  ), // 已完成课程底色透明度
+  fidoCredentialId(key: "fidoCredentialId", type: "String"),
+  fidoPrivateKeyPem(key: "fidoPrivateKeyPem", type: "String"),
+  fidoUserHandle(key: "fidoUserHandle", type: "String"),
+  fidoAnonbiometricsd(key: "fidoAnonbiometricsd", type: "String"),
+  fidoEnabled(key: "fidoEnabled", type: "bool");
 
   const Preference({required this.key, this.type = "String"});
 

--- a/lib/repository/xidian_ids/fido_session.dart
+++ b/lib/repository/xidian_ids/fido_session.dart
@@ -89,28 +89,28 @@ class FidoSession extends IDSSession {
     final startData = startResp.data;
     if (startData is! Map || startData["code"].toString() != "0") {
       throw FidoException(
-        "startRegister 失败: ${startData is Map ? startData["message"] : "响应异常"}",
+        "startRegister failed: ${startData is Map ? startData["message"] : "response error"}",
       );
     }
     final datas = startData["datas"];
     if (datas is! Map) {
-      throw const FidoException("startRegister datas 异常");
+      throw const FidoException("startRegister datas error");
     }
     final request = datas["request"];
     if (request is! Map) {
-      throw const FidoException("startRegister request 异常");
+      throw const FidoException("startRegister request error");
     }
     final requestId = request["requestId"];
     final pkcco = request["publicKeyCredentialCreationOptions"];
     if (pkcco is! Map) {
-      throw const FidoException("startRegister publicKeyCredentialCreationOptions 异常");
+      throw const FidoException("startRegister publicKeyCredentialCreationOptions error");
     }
     final challenge = pkcco["challenge"];
     final rpInfo = pkcco["rp"];
     final userInfo = pkcco["user"];
 
     if (challenge == null || challenge.isEmpty) {
-      throw const FidoException("未获取到 challenge");
+      throw const FidoException("challenge not obtained");
     }
 
     // 2. Generate P-256 key pair
@@ -201,22 +201,22 @@ class FidoSession extends IDSSession {
 
     final finishData = finishResp.data;
     if (finishData is! Map) {
-      throw const FidoException("finishRegister 返回数据异常");
+      throw const FidoException("finishRegister response error");
     }
     final code = finishData["code"];
     if (code.toString() != "0") {
       throw FidoException(
-        "注册失败: ${finishData["message"] ?? "未知错误"}",
+        "Registration failed: ${finishData["message"] ?? "unknown error"}",
       );
     }
 
     final finishDatas = finishData["datas"];
     if (finishDatas is! Map) {
-      throw const FidoException("finishRegister datas 异常");
+      throw const FidoException("finishRegister datas error");
     }
     final anonbiometricsd = finishDatas["anonbiometricsd"];
     if (anonbiometricsd == null || anonbiometricsd.toString().isEmpty) {
-      throw const FidoException("未获取到 anonbiometricsd");
+      throw const FidoException("anonbiometricsd not obtained");
     }
 
     // 5. Save credentials
@@ -281,7 +281,7 @@ class FidoSession extends IDSSession {
     final execution = executionInput?.attributes['value'] ?? '';
 
     if (execution.isEmpty) {
-      throw const FidoException("无法获取 execution token");
+      throw const FidoException("Failed to obtain execution token");
     }
 
     // 2. startAssertion
@@ -312,25 +312,25 @@ class FidoSession extends IDSSession {
 
     final assertData = assertResp.data;
     if (assertData is! Map) {
-      throw const FidoException("startAssertion 返回数据异常");
+      throw const FidoException("startAssertion response error");
     }
     final result = assertData["result"];
     if (result is! Map) {
-      throw const FidoException("startAssertion result 异常");
+      throw const FidoException("startAssertion result error");
     }
     final reqData = result["request"];
     if (reqData is! Map) {
-      throw const FidoException("startAssertion request 异常");
+      throw const FidoException("startAssertion request error");
     }
     final requestId = reqData["requestId"];
     final pkro = reqData["publicKeyCredentialRequestOptions"];
     if (pkro is! Map) {
-      throw const FidoException("startAssertion publicKeyCredentialRequestOptions 异常");
+      throw const FidoException("startAssertion publicKeyCredentialRequestOptions error");
     }
     final challenge = pkro["challenge"];
 
     if (challenge == null || challenge.isEmpty) {
-      throw const FidoException("未获取到 assertion challenge");
+      throw const FidoException("assertion challenge not obtained");
     }
 
     // 3. Generate signature
@@ -390,11 +390,11 @@ class FidoSession extends IDSSession {
     if (loginResp.statusCode == 200) {
       final errPage = html_parser.parse(loginResp.data);
       final errSpan = errPage.querySelector('span#showErrorTip');
-      final errMsg = errSpan?.text ?? "FIDO 登录失败";
+      final errMsg = errSpan?.text ?? "FIDO login failed";
       throw FidoException(errMsg);
     }
 
-    throw FidoException("FIDO 登录失败，状态码: ${loginResp.statusCode}");
+    throw FidoException("FIDO login failed, status: ${loginResp.statusCode}");
   }
 
   // ---------------------------------------------------------------------------

--- a/lib/repository/xidian_ids/fido_session.dart
+++ b/lib/repository/xidian_ids/fido_session.dart
@@ -281,7 +281,7 @@ class FidoSession extends IDSSession {
     final execution = executionInput?.attributes['value'] ?? '';
 
     if (execution.isEmpty) {
-      throw const LoginFailedException(msg: "无法获取 execution token");
+      throw const FidoException("无法获取 execution token");
     }
 
     // 2. startAssertion
@@ -391,12 +391,10 @@ class FidoSession extends IDSSession {
       final errPage = html_parser.parse(loginResp.data);
       final errSpan = errPage.querySelector('span#showErrorTip');
       final errMsg = errSpan?.text ?? "FIDO 登录失败";
-      throw LoginFailedException(msg: errMsg);
+      throw FidoException(errMsg);
     }
 
-    throw LoginFailedException(
-      msg: "FIDO 登录失败，状态码: ${loginResp.statusCode}",
-    );
+    throw FidoException("FIDO 登录失败，状态码: ${loginResp.statusCode}");
   }
 
   // ---------------------------------------------------------------------------

--- a/lib/repository/xidian_ids/fido_session.dart
+++ b/lib/repository/xidian_ids/fido_session.dart
@@ -1,0 +1,715 @@
+// Copyright 2025 Traintime PDA authors.
+// SPDX-License-Identifier: MPL-2.0
+
+// FIDO WebAuthn session for IDS.
+// Handles FIDO registration (soft credential) and FIDO login.
+
+import 'dart:convert';
+import 'dart:io';
+import 'dart:math';
+import 'dart:typed_data';
+
+import 'package:cbor/cbor.dart';
+import 'package:crypto/crypto.dart' as crypto_lib;
+import 'package:device_info_plus/device_info_plus.dart';
+import 'package:dio/dio.dart';
+import 'package:flutter/widgets.dart';
+import 'package:html/parser.dart' as html_parser;
+import 'package:pointycastle/export.dart';
+import 'package:watermeter/repository/logger.dart';
+import 'package:watermeter/repository/preference.dart' as preference;
+import 'package:watermeter/repository/xidian_ids/ids_session.dart';
+
+const _rpId = "ids.xidian.edu.cn";
+const _origin = "https://ids.xidian.edu.cn";
+
+class FidoSession extends IDSSession {
+  // ---------------------------------------------------------------------------
+  // Registration
+  // ---------------------------------------------------------------------------
+
+  /// Register a FIDO soft credential.
+  ///
+  /// Requires recheck (secondary verification) to have been completed beforehand
+  /// via IdsRecheck.recheckByPassword(). Saves credential to preferences on success.
+  Future<void> register({
+    required BuildContext context,
+  }) async {
+    // 0. Visit personalInfo page to establish session cookies
+    await dioNoOfflineCheck.get(
+      "$_origin/personalInfo/personCenter/index.html",
+    );
+
+    // 0.1. Register browser fingerprint with the server.
+    //      The browser's common-header.js generates a fingerprint and sends it
+    //      to /authserver/bfp/info, which sets the MULTIFACTOR_BROWSER_FINGERPRINT cookie.
+    final fingerprint = crypto_lib.md5
+        .convert(utf8.encode("TraintimePDA-${DateTime.now().millisecondsSinceEpoch}"))
+        .toString()
+        .toUpperCase();
+    await dioNoOfflineCheck.get(
+      "https://ids.xidian.edu.cn/authserver/bfp/info",
+      queryParameters: {"bfp": fingerprint},
+    );
+    log.info("[FidoSession] Registered fingerprint: $fingerprint");
+
+    // 1. startRegister
+    // Read REFERERCE_TOKEN cookie for referertoken header
+    final cookies = await cookieJar.loadForRequest(
+      Uri.parse("$_origin/personalInfo"),
+    );
+    final refToken = cookies
+        .where((c) => c.name == "REFERERCE_TOKEN")
+        .firstOrNull
+        ?.value;
+
+    log.info("[FidoSession] Cookies before startRegister: "
+        "${cookies.map((c) => '${c.name}=${c.value.substring(0, c.value.length > 20 ? 20 : c.value.length)}...').join(', ')}");
+
+    final registerHeaders = <String, String>{
+      "X-Requested-With": "XMLHttpRequest",
+      "Origin": _origin,
+      "Referer": "$_origin/personalInfo/personCenter/index.html",
+    };
+    if (refToken != null) {
+      registerHeaders["referertoken"] = refToken;
+    }
+
+    final startResp = await dioNoOfflineCheck.post(
+      "https://ids.xidian.edu.cn/personalInfo/accountSecurity/startRegister",
+      data: {"n": _randomN()},
+      options: Options(
+        contentType: "application/json",
+        headers: registerHeaders,
+      ),
+    );
+
+    log.info("[FidoSession] startRegister response: ${startResp.data}");
+
+    final startData = startResp.data;
+    if (startData is! Map || startData["code"].toString() != "0") {
+      throw FidoException(
+        "startRegister 失败: ${startData is Map ? startData["message"] : "响应异常"}",
+      );
+    }
+    final datas = startData["datas"];
+    if (datas is! Map) {
+      throw const FidoException("startRegister datas 异常");
+    }
+    final request = datas["request"];
+    if (request is! Map) {
+      throw const FidoException("startRegister request 异常");
+    }
+    final requestId = request["requestId"];
+    final pkcco = request["publicKeyCredentialCreationOptions"];
+    if (pkcco is! Map) {
+      throw const FidoException("startRegister publicKeyCredentialCreationOptions 异常");
+    }
+    final challenge = pkcco["challenge"];
+    final rpInfo = pkcco["rp"];
+    final userInfo = pkcco["user"];
+
+    if (challenge == null || challenge.isEmpty) {
+      throw const FidoException("未获取到 challenge");
+    }
+
+    // 2. Generate P-256 key pair
+    log.info("[FidoSession] Generating P-256 key pair...");
+    final keyResult = _generateKeyPair();
+
+    // 3. Build credential
+    final credentialId = _randomBytes(20);
+    final credentialIdB64 = _base64UrlEncode(credentialId);
+
+    final attestationObject = _buildAttestationObject(
+      rpId: rpInfo["id"] ?? _rpId,
+      credentialId: credentialId,
+      publicKey: keyResult.publicKey,
+    );
+
+    final clientDataJson = utf8.encode(jsonEncode({
+      "type": "webauthn.create",
+      "challenge": challenge,
+      "origin": _origin,
+      "crossOrigin": false,
+    }));
+
+    // Note: Vue app's responseToObject drops rawId, only type+id+response+clientExtensionResults
+    final credential = {
+      "type": "public-key",
+      "id": credentialIdB64,
+      "response": {
+        "attestationObject": _base64UrlEncode(attestationObject),
+        "clientDataJSON": _base64UrlEncode(clientDataJson),
+      },
+      "clientExtensionResults": {},
+    };
+
+    log.info("[FidoSession] credential: ${jsonEncode(credential)}");
+
+    // 4. finishRegister
+    final finishCookies = await cookieJar.loadForRequest(
+      Uri.parse("$_origin/personalInfo"),
+    );
+    final finishRefToken = finishCookies
+        .where((c) => c.name == "REFERERCE_TOKEN")
+        .firstOrNull
+        ?.value;
+
+    final finishHeaders = <String, String>{
+      "X-Requested-With": "XMLHttpRequest",
+      "Origin": _origin,
+      "Referer": "$_origin/personalInfo/personCenter/index.html",
+    };
+    if (finishRefToken != null) {
+      finishHeaders["referertoken"] = finishRefToken;
+    }
+
+    // Generate unique device name from device info
+    final deviceInfo = DeviceInfoPlugin();
+    String deviceName = "Traintime PDA";
+    if (Platform.isAndroid) {
+      final info = await deviceInfo.androidInfo;
+      deviceName = "PDA ${info.model}";
+    } else if (Platform.isIOS) {
+      final info = await deviceInfo.iosInfo;
+      deviceName = "PDA ${info.name}";
+    } else if (Platform.isMacOS) {
+      final info = await deviceInfo.macOsInfo;
+      deviceName = "PDA ${info.computerName}";
+    }
+
+    final finishResp = await dioNoOfflineCheck.post(
+      "https://ids.xidian.edu.cn/personalInfo/accountSecurity/finishRegister",
+      data: {
+        "deviceName": deviceName,
+        "anonbiometricsd": null,
+        "response": jsonEncode({
+          "requestId": requestId,
+          "credential": credential,
+          "sessionToken": null,
+        }),
+        "n": _randomN(),
+      },
+      options: Options(
+        contentType: "application/json",
+        headers: finishHeaders,
+      ),
+    );
+
+    log.info("[FidoSession] finishRegister response: ${finishResp.data}");
+
+    final finishData = finishResp.data;
+    if (finishData is! Map) {
+      throw const FidoException("finishRegister 返回数据异常");
+    }
+    final code = finishData["code"];
+    if (code.toString() != "0") {
+      throw FidoException(
+        "注册失败: ${finishData["message"] ?? "未知错误"}",
+      );
+    }
+
+    final finishDatas = finishData["datas"];
+    if (finishDatas is! Map) {
+      throw const FidoException("finishRegister datas 异常");
+    }
+    final anonbiometricsd = finishDatas["anonbiometricsd"];
+    if (anonbiometricsd == null || anonbiometricsd.toString().isEmpty) {
+      throw const FidoException("未获取到 anonbiometricsd");
+    }
+
+    // 5. Save credentials
+    await preference.setString(
+      preference.Preference.fidoCredentialId,
+      credentialIdB64,
+    );
+    await preference.setString(
+      preference.Preference.fidoPrivateKeyPem,
+      keyResult.privateKeyPem,
+    );
+    await preference.setString(
+      preference.Preference.fidoUserHandle,
+      userInfo["id"] ?? "",
+    );
+    await preference.setString(
+      preference.Preference.fidoAnonbiometricsd,
+      anonbiometricsd,
+    );
+    await preference.setBool(preference.Preference.fidoEnabled, true);
+
+    log.info("[FidoSession] FIDO registration successful.");
+  }
+
+  // ---------------------------------------------------------------------------
+  // FIDO Login
+  // ---------------------------------------------------------------------------
+
+  /// Login via FIDO assertion.
+  ///
+  /// Returns the redirect location URL on success.
+  Future<String> fidoLogin({
+    String? target,
+    void Function(int, String)? onResponse,
+  }) async {
+    if (onResponse != null) onResponse(10, "fido_process.prepare");
+
+    // 1. GET login page -> parse execution token
+    final loginParams = <String, String>{'type': 'userNameLogin'};
+    if (target != null) loginParams['service'] = target;
+
+    final loginPage = await dioNoOfflineCheck.get(
+      "https://ids.xidian.edu.cn/authserver/login",
+      queryParameters: loginParams,
+      options: Options(
+        validateStatus: (s) => s != null && s >= 200 && s < 400,
+      ),
+    );
+
+    // If already logged in, server returns 302 with the target URL
+    if (loginPage.statusCode == 301 || loginPage.statusCode == 302) {
+      final location = loginPage.headers[HttpHeaders.locationHeader];
+      if (location != null && location.isNotEmpty) {
+        loginState = IDSLoginState.success;
+        if (onResponse != null) onResponse(100, "fido_process.done");
+        return location.first;
+      }
+    }
+
+    final page = html_parser.parse(loginPage.data);
+    final executionInput = page.querySelector('input[name="execution"]');
+    final execution = executionInput?.attributes['value'] ?? '';
+
+    if (execution.isEmpty) {
+      throw const LoginFailedException(msg: "无法获取 execution token");
+    }
+
+    // 2. startAssertion
+    if (onResponse != null) onResponse(30, "fido_process.start_assertion");
+
+    final username = preference.getString(preference.Preference.idsAccount);
+    final usernameB64 = base64.encode(utf8.encode(username));
+    final anonbiometricsd =
+        preference.getString(preference.Preference.fidoAnonbiometricsd);
+
+    final assertResp = await dioNoOfflineCheck.post(
+      "https://ids.xidian.edu.cn/authserver/startAssertion",
+      data: jsonEncode({
+        "userId": usernameB64,
+        "id": anonbiometricsd,
+      }),
+      options: Options(
+        contentType: "application/json;charset=UTF-8",
+        headers: {
+          "Accept": "application/json, text/javascript, */*; q=0.01",
+          "X-Requested-With": "XMLHttpRequest",
+          "Referer": "https://ids.xidian.edu.cn/authserver/login",
+        },
+      ),
+    );
+
+    log.info("[FidoSession] startAssertion response: ${assertResp.data}");
+
+    final assertData = assertResp.data;
+    if (assertData is! Map) {
+      throw const FidoException("startAssertion 返回数据异常");
+    }
+    final result = assertData["result"];
+    if (result is! Map) {
+      throw const FidoException("startAssertion result 异常");
+    }
+    final reqData = result["request"];
+    if (reqData is! Map) {
+      throw const FidoException("startAssertion request 异常");
+    }
+    final requestId = reqData["requestId"];
+    final pkro = reqData["publicKeyCredentialRequestOptions"];
+    if (pkro is! Map) {
+      throw const FidoException("startAssertion publicKeyCredentialRequestOptions 异常");
+    }
+    final challenge = pkro["challenge"];
+
+    if (challenge == null || challenge.isEmpty) {
+      throw const FidoException("未获取到 assertion challenge");
+    }
+
+    // 3. Generate signature
+    if (onResponse != null) onResponse(50, "fido_process.signing");
+
+    final privateKeyPem =
+        preference.getString(preference.Preference.fidoPrivateKeyPem);
+    final credentialId =
+        preference.getString(preference.Preference.fidoCredentialId);
+    final userHandle =
+        preference.getString(preference.Preference.fidoUserHandle);
+
+    final assertion = _makeAssertion(
+      challenge: challenge,
+      credentialId: credentialId,
+      privateKeyPem: privateKeyPem,
+      userHandle: userHandle,
+    );
+
+    // 4. Submit FIDO login form
+    if (onResponse != null) onResponse(70, "fido_process.submitting");
+
+    final responseJson = jsonEncode({
+      "requestId": requestId,
+      "credential": assertion,
+      "sessionToken": null,
+    });
+
+    final formData = {
+      "_eventId": "submit",
+      "username": usernameB64,
+      "responseJson": responseJson,
+      "cllt": "fidoLogin",
+      "dllt": "generalLogin",
+      "lt": "",
+      "execution": execution,
+    };
+
+    final loginResp = await dioNoOfflineCheck.post(
+      "https://ids.xidian.edu.cn/authserver/login",
+      queryParameters: target != null ? {'service': target} : null,
+      data: formData,
+      options: Options(
+        contentType: "application/x-www-form-urlencoded",
+        validateStatus: (s) => s != null && s >= 200 && s < 400,
+      ),
+    );
+
+    log.info("[FidoSession] FIDO login status: ${loginResp.statusCode}");
+
+    if (loginResp.statusCode == 301 || loginResp.statusCode == 302) {
+      if (onResponse != null) onResponse(80, "fido_process.done");
+      return loginResp.headers[HttpHeaders.locationHeader]![0];
+    }
+
+    // Check for error in 200 response
+    if (loginResp.statusCode == 200) {
+      final errPage = html_parser.parse(loginResp.data);
+      final errSpan = errPage.querySelector('span#showErrorTip');
+      final errMsg = errSpan?.text ?? "FIDO 登录失败";
+      throw LoginFailedException(msg: errMsg);
+    }
+
+    throw LoginFailedException(
+      msg: "FIDO 登录失败，状态码: ${loginResp.statusCode}",
+    );
+  }
+
+  // ---------------------------------------------------------------------------
+  // WebAuthn Crypto Helpers
+  // ---------------------------------------------------------------------------
+
+  _KeyPairResult _generateKeyPair() {
+    final secureRandom = FortunaRandom();
+    secureRandom.seed(KeyParameter(_randomBytes(32)));
+
+    final domainParams = ECDomainParameters("secp256r1");
+    final keyParams = ECKeyGeneratorParameters(domainParams);
+    final generator = ECKeyGenerator()
+      ..init(ParametersWithRandom(keyParams, secureRandom));
+
+    final keyPair = generator.generateKeyPair();
+    final privateKey = keyPair.privateKey;
+    final publicKey = keyPair.publicKey;
+
+    // Export private key as PKCS#8 PEM
+    final privateKeyPem = _exportPrivateKeyPem(privateKey, publicKey);
+
+    return _KeyPairResult(
+      privateKey: privateKey,
+      publicKey: publicKey,
+      privateKeyPem: privateKeyPem,
+    );
+  }
+
+  Uint8List _buildAttestationObject({
+    required String rpId,
+    required Uint8List credentialId,
+    required ECPublicKey publicKey,
+  }) {
+    final rpIdHash = crypto_lib.sha256.convert(utf8.encode(rpId)).bytes;
+    const flags = 0x41; // UP + AT
+    final signCount = [0, 0, 0, 0];
+    final aaguid = List.filled(16, 0);
+    final credIdLen = [
+      (credentialId.length >> 8) & 0xFF,
+      credentialId.length & 0xFF,
+    ];
+
+    // COSE EC2 public key
+    final x = _bigIntToBytes(publicKey.Q!.x!.toBigInteger()!, 32);
+    final y = _bigIntToBytes(publicKey.Q!.y!.toBigInteger()!, 32);
+    final coseKey = CborMap({
+      CborSmallInt(1): CborSmallInt(2), // kty: EC2
+      CborSmallInt(3): CborValue(-7), // alg: ES256
+      CborSmallInt(-1): CborSmallInt(1), // crv: P-256
+      CborSmallInt(-2): CborBytes(x), // x
+      CborSmallInt(-3): CborBytes(y), // y
+    });
+
+    final coseKeyBytes = cborEncode(coseKey);
+    log.info("[FidoSession] COSE key bytes (${coseKeyBytes.length}): ${coseKeyBytes.map((b) => b.toRadixString(16).padLeft(2, '0')).join(' ')}");
+
+    final authData = Uint8List.fromList([
+      ...rpIdHash,
+      flags,
+      ...signCount,
+      ...aaguid,
+      ...credIdLen,
+      ...credentialId,
+      ...coseKeyBytes,
+    ]);
+    log.info("[FidoSession] authData (${authData.length} bytes): ${authData.map((b) => b.toRadixString(16).padLeft(2, '0')).join(' ')}");
+
+    final attObj = CborMap({
+      CborString("fmt"): CborString("none"),
+      CborString("attStmt"): CborMap({}),
+      CborString("authData"): CborBytes(authData),
+    });
+
+    return Uint8List.fromList(cborEncode(attObj));
+  }
+
+  Map<String, dynamic> _makeAssertion({
+    required String challenge,
+    required String credentialId,
+    required String privateKeyPem,
+    required String userHandle,
+  }) {
+    final privateKey = _loadPrivateKeyFromPem(privateKeyPem);
+
+    // clientDataJSON
+    final clientData = utf8.encode(jsonEncode({
+      "type": "webauthn.get",
+      "challenge": challenge,
+      "origin": _origin,
+      "crossOrigin": false,
+    }));
+
+    // authenticatorData
+    final rpIdHash = crypto_lib.sha256.convert(utf8.encode(_rpId)).bytes;
+    const flags = 0x05; // UP + UV
+    final authenticatorData = Uint8List.fromList([
+      ...rpIdHash,
+      flags,
+      0,
+      0,
+      0,
+      0,
+    ]);
+
+    // Sign: authenticatorData || SHA256(clientDataJSON)
+    final clientDataHash = crypto_lib.sha256.convert(clientData).bytes;
+    final signedBytes = Uint8List.fromList([
+      ...authenticatorData,
+      ...clientDataHash,
+    ]);
+
+    final signer = Signer("SHA-256/ECDSA")
+      ..init(true, PrivateKeyParameter(privateKey));
+    final signature = signer.generateSignature(signedBytes) as ECSignature;
+    final derSig = _encodeDerSignature(signature.r, signature.s);
+
+    return {
+      "type": "public-key",
+      "id": credentialId,
+      "response": {
+        "authenticatorData": _base64UrlEncode(authenticatorData),
+        "clientDataJSON": _base64UrlEncode(clientData),
+        "signature": _base64UrlEncode(derSig),
+        "userHandle": userHandle,
+      },
+      "clientExtensionResults": {"appid": false},
+    };
+  }
+
+  // ---------------------------------------------------------------------------
+  // PEM / DER Helpers
+  // ---------------------------------------------------------------------------
+
+  String _exportPrivateKeyPem(ECPrivateKey privateKey, ECPublicKey publicKey) {
+    final d = _bigIntToBytes(privateKey.d!, 32);
+
+    // PKCS#8 PrivateKeyInfo DER encoding for EC P-256
+    final ecPoint = publicKey.Q!;
+    final pubX = _bigIntToBytes(ecPoint.x!.toBigInteger()!, 32);
+    final pubY = _bigIntToBytes(ecPoint.y!.toBigInteger()!, 32);
+    final uncompressedPub = Uint8List.fromList([0x04, ...pubX, ...pubY]);
+
+    final innerSeq = _derSequence([
+      _derInteger(BigInt.from(1)),
+      _derOctetString(d),
+      _derBitString(uncompressedPub, tag: 0xA1),
+    ]);
+
+    final algorithmSeq = _derSequence([
+      _derOid([1, 2, 840, 10045, 2, 1]),
+      _derOid([1, 2, 840, 10045, 3, 1, 7]),
+    ]);
+
+    final pkcs8Seq = _derSequence([
+      _derInteger(BigInt.zero),
+      algorithmSeq,
+      _derOctetString(innerSeq),
+    ]);
+
+    final b64 = base64.encode(pkcs8Seq);
+    final pemLines = RegExp(r'.{1,64}').allMatches(b64).map((m) => m.group(0));
+    return "-----BEGIN PRIVATE KEY-----\n${pemLines.join("\n")}\n-----END PRIVATE KEY-----";
+  }
+
+  ECPrivateKey _loadPrivateKeyFromPem(String pem) {
+    final b64 = pem
+        .replaceAll("-----BEGIN PRIVATE KEY-----", "")
+        .replaceAll("-----END PRIVATE KEY-----", "")
+        .replaceAll(RegExp(r'\s+'), "");
+    final der = base64.decode(b64);
+
+    // Extract the private key integer 'd' from PKCS#8 DER.
+    final dBytes = _extractPrivateKeyD(der);
+    final d = _bytesToBigInt(dBytes);
+
+    final domainParams = ECDomainParameters("secp256r1");
+    return ECPrivateKey(d, domainParams);
+  }
+
+  Uint8List _extractPrivateKeyD(Uint8List pkcs8Der) {
+    // Navigate the DER structure to find the private key octet string.
+    // After the outer SEQUENCE, skip: version INT (5 bytes), algorithm SEQ (~18 bytes),
+    // then the private key OCTET STRING wraps an inner SEQUENCE with: version INT, OCT(d).
+    // We search for the pattern: 0x04, 0x20 (OCTET STRING, 32 bytes) after 0x02, 0x01, 0x00 (INT 1).
+    for (int i = 0; i < pkcs8Der.length - 34; i++) {
+      // Look for inner SEQUENCE start containing INT 1 then OCTET STRING(32)
+      if (pkcs8Der[i] == 0x02 &&
+          pkcs8Der[i + 1] == 0x01 &&
+          pkcs8Der[i + 2] == 0x01 &&
+          pkcs8Der[i + 3] == 0x04 &&
+          pkcs8Der[i + 4] == 0x20) {
+        return pkcs8Der.sublist(i + 5, i + 5 + 32);
+      }
+    }
+    throw const FidoException("Failed to extract private key from PEM");
+  }
+
+  Uint8List _encodeDerSignature(BigInt r, BigInt s) {
+    return _derSequence([
+      _derIntegerRaw(_bigIntToBytes(r, 32)),
+      _derIntegerRaw(_bigIntToBytes(s, 32)),
+    ]);
+  }
+
+  Uint8List _derSequence(List<Uint8List> items) {
+    final content = Uint8List.fromList(items.expand((i) => i).toList());
+    return _derTlv(0x30, content);
+  }
+
+  Uint8List _derInteger(BigInt value) {
+    final bytes = _bigIntToBytes(value, (value.bitLength + 7) ~/ 8 + 1);
+    return _derTlv(0x02, bytes);
+  }
+
+  Uint8List _derIntegerRaw(Uint8List value) {
+    // Add leading zero if high bit is set
+    Uint8List adjusted;
+    if (value.isNotEmpty && (value[0] & 0x80) != 0) {
+      adjusted = Uint8List.fromList([0x00, ...value]);
+    } else {
+      adjusted = value;
+    }
+    return _derTlv(0x02, adjusted);
+  }
+
+  Uint8List _derOctetString(Uint8List value) {
+    return _derTlv(0x04, value);
+  }
+
+  Uint8List _derBitString(Uint8List value, {int tag = 0x03}) {
+    final content = Uint8List.fromList([0x00, ...value]);
+    return _derTlv(tag, content);
+  }
+
+  Uint8List _derOid(List<int> components) {
+    final bytes = <int>[
+      components[0] * 40 + components[1],
+      for (int i = 2; i < components.length; i++) ..._encodeOidComponent(components[i]),
+    ];
+    return _derTlv(0x06, Uint8List.fromList(bytes));
+  }
+
+  List<int> _encodeOidComponent(int value) {
+    if (value < 0x80) return [value];
+    final result = <int>[];
+    int v = value;
+    result.add(v & 0x7F);
+    v >>= 7;
+    while (v > 0) {
+      result.add((v & 0x7F) | 0x80);
+      v >>= 7;
+    }
+    return result.reversed.toList();
+  }
+
+  Uint8List _derTlv(int tag, Uint8List value) {
+    final lengthBytes = _derLength(value.length);
+    return Uint8List.fromList([tag, ...lengthBytes, ...value]);
+  }
+
+  List<int> _derLength(int length) {
+    if (length < 0x80) return [length];
+    if (length < 0x100) return [0x81, length];
+    return [0x82, (length >> 8) & 0xFF, length & 0xFF];
+  }
+
+  // ---------------------------------------------------------------------------
+  // Utility
+  // ---------------------------------------------------------------------------
+
+  Uint8List _randomBytes(int length) {
+    return Uint8List.fromList(
+      List.generate(length, (_) => Random.secure().nextInt(256)),
+    );
+  }
+
+  String _randomN() {
+    return (DateTime.now().millisecondsSinceEpoch / 1000).toStringAsFixed(17);
+  }
+
+  String _base64UrlEncode(List<int> data) {
+    return base64Url.encode(data).replaceAll("=", "");
+  }
+
+  Uint8List _bigIntToBytes(BigInt value, int length) {
+    final hex = value.toRadixString(16).padLeft(length * 2, '0');
+    return Uint8List.fromList(List.generate(
+      length,
+      (i) => int.parse(hex.substring(i * 2, i * 2 + 2), radix: 16),
+    ));
+  }
+
+  BigInt _bytesToBigInt(Uint8List bytes) {
+    return BigInt.parse(bytes.map((b) => b.toRadixString(16).padLeft(2, '0')).join(), radix: 16);
+  }
+}
+
+class _KeyPairResult {
+  final ECPrivateKey privateKey;
+  final ECPublicKey publicKey;
+  final String privateKeyPem;
+
+  _KeyPairResult({
+    required this.privateKey,
+    required this.publicKey,
+    required this.privateKeyPem,
+  });
+}
+
+class FidoException implements Exception {
+  final String msg;
+  const FidoException(this.msg);
+  @override
+  String toString() => msg;
+}

--- a/lib/repository/xidian_ids/fido_session.dart
+++ b/lib/repository/xidian_ids/fido_session.dart
@@ -16,6 +16,7 @@ import 'package:dio/dio.dart';
 import 'package:flutter/widgets.dart';
 import 'package:html/parser.dart' as html_parser;
 import 'package:pointycastle/export.dart';
+import 'package:pointycastle/asn1.dart';
 import 'package:watermeter/repository/logger.dart';
 import 'package:watermeter/repository/preference.dart' as preference;
 import 'package:watermeter/repository/xidian_ids/ids_session.dart';
@@ -416,8 +417,35 @@ class FidoSession extends IDSSession {
     final privateKey = keyPair.privateKey;
     final publicKey = keyPair.publicKey;
 
-    // Export private key as PKCS#8 PEM
-    final privateKeyPem = _exportPrivateKeyPem(privateKey, publicKey);
+    // Export private key as PKCS#8 PEM using PointyCastle ASN1
+    final ecPoint = publicKey.Q!;
+    final pubX = _bigIntToBytes(ecPoint.x!.toBigInteger()!, 32);
+    final pubY = _bigIntToBytes(ecPoint.y!.toBigInteger()!, 32);
+    final uncompressedPub = Uint8List.fromList([0x04, ...pubX, ...pubY]);
+
+    final innerSeq = ASN1Sequence(elements: [
+      ASN1Integer(BigInt.from(1)),
+      ASN1OctetString(octets: _bigIntToBytes(privateKey.d!, 32)),
+      ASN1BitString(
+          stringValues: uncompressedPub, tag: 0xA1),
+    ]);
+
+    final algorithmSeq = ASN1Sequence(elements: [
+      ASN1ObjectIdentifier([1, 2, 840, 10045, 2, 1]),
+      ASN1ObjectIdentifier([1, 2, 840, 10045, 3, 1, 7]),
+    ]);
+
+    final pkcs8Seq = ASN1Sequence(elements: [
+      ASN1Integer(BigInt.zero),
+      algorithmSeq,
+      ASN1OctetString(octets: innerSeq.encode()),
+    ]);
+
+    final b64 = base64.encode(pkcs8Seq.encode());
+    final pemLines =
+        RegExp(r'.{1,64}').allMatches(b64).map((m) => m.group(0));
+    final privateKeyPem =
+        "-----BEGIN PRIVATE KEY-----\n${pemLines.join("\n")}\n-----END PRIVATE KEY-----";
 
     return _KeyPairResult(
       privateKey: privateKey,
@@ -480,7 +508,8 @@ class FidoSession extends IDSSession {
     required String privateKeyPem,
     required String userHandle,
   }) {
-    final privateKey = _loadPrivateKeyFromPem(privateKeyPem);
+    final derBytes = ASN1Utils.getBytesFromPEMString(privateKeyPem);
+    final privateKey = ASN1Utils.ecPrivateKeyFromDerBytes(derBytes, pkcs8: true);
 
     // clientDataJSON
     final clientData = utf8.encode(jsonEncode({
@@ -528,140 +557,22 @@ class FidoSession extends IDSSession {
   }
 
   // ---------------------------------------------------------------------------
-  // PEM / DER Helpers
+  // Signature DER Encoding
   // ---------------------------------------------------------------------------
 
-  String _exportPrivateKeyPem(ECPrivateKey privateKey, ECPublicKey publicKey) {
-    final d = _bigIntToBytes(privateKey.d!, 32);
-
-    // PKCS#8 PrivateKeyInfo DER encoding for EC P-256
-    final ecPoint = publicKey.Q!;
-    final pubX = _bigIntToBytes(ecPoint.x!.toBigInteger()!, 32);
-    final pubY = _bigIntToBytes(ecPoint.y!.toBigInteger()!, 32);
-    final uncompressedPub = Uint8List.fromList([0x04, ...pubX, ...pubY]);
-
-    final innerSeq = _derSequence([
-      _derInteger(BigInt.from(1)),
-      _derOctetString(d),
-      _derBitString(uncompressedPub, tag: 0xA1),
-    ]);
-
-    final algorithmSeq = _derSequence([
-      _derOid([1, 2, 840, 10045, 2, 1]),
-      _derOid([1, 2, 840, 10045, 3, 1, 7]),
-    ]);
-
-    final pkcs8Seq = _derSequence([
-      _derInteger(BigInt.zero),
-      algorithmSeq,
-      _derOctetString(innerSeq),
-    ]);
-
-    final b64 = base64.encode(pkcs8Seq);
-    final pemLines = RegExp(r'.{1,64}').allMatches(b64).map((m) => m.group(0));
-    return "-----BEGIN PRIVATE KEY-----\n${pemLines.join("\n")}\n-----END PRIVATE KEY-----";
-  }
-
-  ECPrivateKey _loadPrivateKeyFromPem(String pem) {
-    final b64 = pem
-        .replaceAll("-----BEGIN PRIVATE KEY-----", "")
-        .replaceAll("-----END PRIVATE KEY-----", "")
-        .replaceAll(RegExp(r'\s+'), "");
-    final der = base64.decode(b64);
-
-    // Extract the private key integer 'd' from PKCS#8 DER.
-    final dBytes = _extractPrivateKeyD(der);
-    final d = _bytesToBigInt(dBytes);
-
-    final domainParams = ECDomainParameters("secp256r1");
-    return ECPrivateKey(d, domainParams);
-  }
-
-  Uint8List _extractPrivateKeyD(Uint8List pkcs8Der) {
-    // Navigate the DER structure to find the private key octet string.
-    // After the outer SEQUENCE, skip: version INT (5 bytes), algorithm SEQ (~18 bytes),
-    // then the private key OCTET STRING wraps an inner SEQUENCE with: version INT, OCT(d).
-    // We search for the pattern: 0x04, 0x20 (OCTET STRING, 32 bytes) after 0x02, 0x01, 0x00 (INT 1).
-    for (int i = 0; i < pkcs8Der.length - 34; i++) {
-      // Look for inner SEQUENCE start containing INT 1 then OCTET STRING(32)
-      if (pkcs8Der[i] == 0x02 &&
-          pkcs8Der[i + 1] == 0x01 &&
-          pkcs8Der[i + 2] == 0x01 &&
-          pkcs8Der[i + 3] == 0x04 &&
-          pkcs8Der[i + 4] == 0x20) {
-        return pkcs8Der.sublist(i + 5, i + 5 + 32);
-      }
-    }
-    throw const FidoException("Failed to extract private key from PEM");
-  }
-
   Uint8List _encodeDerSignature(BigInt r, BigInt s) {
-    return _derSequence([
-      _derIntegerRaw(_bigIntToBytes(r, 32)),
-      _derIntegerRaw(_bigIntToBytes(s, 32)),
-    ]);
-  }
-
-  Uint8List _derSequence(List<Uint8List> items) {
-    final content = Uint8List.fromList(items.expand((i) => i).toList());
-    return _derTlv(0x30, content);
-  }
-
-  Uint8List _derInteger(BigInt value) {
-    final bytes = _bigIntToBytes(value, (value.bitLength + 7) ~/ 8 + 1);
-    return _derTlv(0x02, bytes);
-  }
-
-  Uint8List _derIntegerRaw(Uint8List value) {
-    // Add leading zero if high bit is set
-    Uint8List adjusted;
-    if (value.isNotEmpty && (value[0] & 0x80) != 0) {
-      adjusted = Uint8List.fromList([0x00, ...value]);
-    } else {
-      adjusted = value;
+    List<int> encodeInt(BigInt value) {
+      var bytes = _bigIntToBytes(value, 32);
+      if (bytes[0] & 0x80 != 0) {
+        bytes = Uint8List.fromList([0x00, ...bytes]);
+      }
+      return [0x02, bytes.length, ...bytes];
     }
-    return _derTlv(0x02, adjusted);
-  }
 
-  Uint8List _derOctetString(Uint8List value) {
-    return _derTlv(0x04, value);
-  }
-
-  Uint8List _derBitString(Uint8List value, {int tag = 0x03}) {
-    final content = Uint8List.fromList([0x00, ...value]);
-    return _derTlv(tag, content);
-  }
-
-  Uint8List _derOid(List<int> components) {
-    final bytes = <int>[
-      components[0] * 40 + components[1],
-      for (int i = 2; i < components.length; i++) ..._encodeOidComponent(components[i]),
-    ];
-    return _derTlv(0x06, Uint8List.fromList(bytes));
-  }
-
-  List<int> _encodeOidComponent(int value) {
-    if (value < 0x80) return [value];
-    final result = <int>[];
-    int v = value;
-    result.add(v & 0x7F);
-    v >>= 7;
-    while (v > 0) {
-      result.add((v & 0x7F) | 0x80);
-      v >>= 7;
-    }
-    return result.reversed.toList();
-  }
-
-  Uint8List _derTlv(int tag, Uint8List value) {
-    final lengthBytes = _derLength(value.length);
-    return Uint8List.fromList([tag, ...lengthBytes, ...value]);
-  }
-
-  List<int> _derLength(int length) {
-    if (length < 0x80) return [length];
-    if (length < 0x100) return [0x81, length];
-    return [0x82, (length >> 8) & 0xFF, length & 0xFF];
+    final rEnc = encodeInt(r);
+    final sEnc = encodeInt(s);
+    final content = [...rEnc, ...sEnc];
+    return Uint8List.fromList([0x30, content.length, ...content]);
   }
 
   // ---------------------------------------------------------------------------
@@ -690,9 +601,6 @@ class FidoSession extends IDSSession {
     ));
   }
 
-  BigInt _bytesToBigInt(Uint8List bytes) {
-    return BigInt.parse(bytes.map((b) => b.toRadixString(16).padLeft(2, '0')).join(), radix: 16);
-  }
 }
 
 class _KeyPairResult {

--- a/lib/repository/xidian_ids/fido_session.dart
+++ b/lib/repository/xidian_ids/fido_session.dart
@@ -24,6 +24,8 @@ const _rpId = "ids.xidian.edu.cn";
 const _origin = "https://ids.xidian.edu.cn";
 
 class FidoSession extends IDSSession {
+  static final _secureRandom = Random.secure();
+
   // ---------------------------------------------------------------------------
   // Registration
   // ---------------------------------------------------------------------------
@@ -668,7 +670,7 @@ class FidoSession extends IDSSession {
 
   Uint8List _randomBytes(int length) {
     return Uint8List.fromList(
-      List.generate(length, (_) => Random.secure().nextInt(256)),
+      List.generate(length, (_) => _secureRandom.nextInt(256)),
     );
   }
 

--- a/lib/repository/xidian_ids/ids_crypto.dart
+++ b/lib/repository/xidian_ids/ids_crypto.dart
@@ -1,0 +1,54 @@
+// Copyright 2025 Traintime PDA authors.
+// SPDX-License-Identifier: MPL-2.0
+
+// Shared AES encryption utilities for IDS (统一认证服务).
+// Used by both slider captcha payload encryption and recheck password encryption.
+
+import 'dart:math';
+import 'dart:typed_data';
+import 'package:encrypter_plus/encrypter_plus.dart' as encrypt;
+
+class IdsCrypto {
+  static const String aesChars =
+      "ABCDEFGHJKMNPQRSTWXYZabcdefhijkmnprstwxyz2345678";
+  static const int _blockSize = 16;
+  static final Random _random = Random.secure();
+
+  /// Generate a random string of [length] characters from [aesChars].
+  ///
+  /// Character set excludes easily confused characters: I/L/O/i/l/o/0/1/9.
+  static String randomString(int length) {
+    return String.fromCharCodes(
+      List.generate(
+        length,
+        (_) => aesChars.codeUnitAt(_random.nextInt(aesChars.length)),
+      ),
+    );
+  }
+
+  /// IDS standard AES-CBC password encryption.
+  ///
+  /// Plaintext = randomString(64) + [plainText]
+  /// Key = [keyBytes] (typically 16 bytes, UTF-8 encoded)
+  /// IV = randomString(16), UTF-8 encoded
+  /// Padding = PKCS7
+  /// Output = Base64(ciphertext), IV is NOT included.
+  ///
+  /// Used by:
+  /// - Slider captcha: key from image tail bytes
+  /// - Recheck: key from WIS_PER_ENC cookie
+  static String encryptPassword(String plainText, Uint8List keyBytes) {
+    final ivStr = randomString(_blockSize);
+    final nonce = randomString(_blockSize * 4);
+    final plain = nonce + plainText;
+
+    final key = encrypt.Key(keyBytes);
+    final iv = encrypt.IV.fromUtf8(ivStr);
+
+    final encrypter = encrypt.Encrypter(
+      encrypt.AES(key, mode: encrypt.AESMode.cbc),
+    );
+
+    return encrypter.encrypt(plain, iv: iv).base64;
+  }
+}

--- a/lib/repository/xidian_ids/ids_recheck.dart
+++ b/lib/repository/xidian_ids/ids_recheck.dart
@@ -1,0 +1,214 @@
+// Copyright 2025 Traintime PDA authors.
+// SPDX-License-Identifier: MPL-2.0
+
+// IDS recheck (二次验证) service.
+// Handles secondary authentication for sensitive personalInfo operations
+// (FIDO registration, password change, etc.).
+
+import 'dart:convert';
+import 'dart:io';
+import 'dart:typed_data';
+
+import 'package:dio/dio.dart';
+import 'package:flutter/material.dart';
+import 'package:watermeter/page/login/image_captcha.dart';
+import 'package:watermeter/repository/xidian_ids/ids_crypto.dart';
+import 'package:watermeter/repository/xidian_ids/ids_session.dart';
+
+class IdsRecheck extends IDSSession {
+  static const _personalInfoService =
+      "https://ids.xidian.edu.cn/personalInfo/index.html";
+
+  /// Ensure authenticated session for /personalInfo endpoints.
+  ///
+  /// The main IDS login may not cover /personalInfo service.
+  /// This hits the login endpoint with the personalInfo service URL.
+  /// If already logged in, the server returns 302 with a service ticket;
+  /// we follow the redirect chain to redeem it.
+  Future<void> ensurePersonalInfoSession() async {
+    var response = await dioNoOfflineCheck.get(
+      "https://ids.xidian.edu.cn/authserver/login",
+      queryParameters: {
+        'type': 'userNameLogin',
+        'service': _personalInfoService,
+      },
+    );
+
+    // Follow redirect chain to redeem service ticket
+    while (response.statusCode == 301 || response.statusCode == 302) {
+      final locations = response.headers[HttpHeaders.locationHeader];
+      if (locations == null || locations.isEmpty) break;
+      response = await dioNoOfflineCheck.get(locations.first);
+    }
+  }
+
+  /// Check if secondary verification is required.
+  ///
+  /// Returns true if recheck is needed (either necessary=true or expired/missing).
+  /// Returns false only when the server confirms recheck is NOT needed.
+  Future<bool> isNecessary() async {
+    final resp = await dioNoOfflineCheck.get(
+      "https://ids.xidian.edu.cn/personalInfo/common/isUserRecheckNecessary",
+      queryParameters: {"t": DateTime.now().millisecondsSinceEpoch.toString()},
+    );
+    final data = resp.data;
+    if (data is Map) {
+      final code = data["code"];
+      // 2106010002 = "二次校验已失效" → recheck expired, need to redo
+      if (code.toString() == "2106010002") return true;
+      if (data["datas"] is Map) {
+        return data["datas"]["necessary"] == true;
+      }
+    }
+    return false;
+  }
+
+  /// Get available recheck approach.
+  /// Returns: "password", "phone", "email", "otp"
+  Future<String> getApproach() async {
+    final resp = await dioNoOfflineCheck.post(
+      "https://ids.xidian.edu.cn/personalInfo/common/recheckApproach",
+      data: {"n": _randomN()},
+      options: Options(contentType: "application/json"),
+    );
+    final data = resp.data;
+    if (data is Map && data["datas"] is Map) {
+      return data["datas"]["approachName"] ?? "password";
+    }
+    return "password";
+  }
+
+  /// Fetch captcha image bytes for recheck.
+  Future<Uint8List> fetchCaptchaImage() async {
+    final resp = await dioNoOfflineCheck.get(
+      "https://ids.xidian.edu.cn/personalInfo/captcha/checkCode",
+      queryParameters: {"data": DateTime.now().millisecondsSinceEpoch.toString()},
+      options: Options(responseType: ResponseType.bytes),
+    );
+    return Uint8List.fromList(resp.data);
+  }
+
+  /// Perform password-based recheck.
+  ///
+  /// 1. Fetches captcha image
+  /// 2. Shows ImageCaptchaWidget for user input
+  /// 3. Reads WIS_PER_ENC cookie as AES key
+  /// 4. Encrypts password with IdsCrypto
+  /// 5. POSTs to /common/reCheckPwd
+  ///
+  /// Returns the sign value on success.
+  Future<String> recheckByPassword({
+    required BuildContext context,
+    required String password,
+  }) async {
+    // 1. Fetch captcha
+    final captchaImage = await fetchCaptchaImage();
+
+    // 2. Show captcha widget
+    if (!context.mounted) throw RecheckCancelledException();
+    final captchaCode = await Navigator.of(context).push<String>(
+      MaterialPageRoute(
+        builder: (_) => ImageCaptchaWidget(
+          initialImage: captchaImage,
+          onRefresh: fetchCaptchaImage,
+        ),
+      ),
+    );
+    if (captchaCode == null) throw RecheckCancelledException();
+
+    // 3. Read WIS_PER_ENC cookie
+    final cookies = await cookieJar.loadForRequest(
+      Uri.parse("https://ids.xidian.edu.cn/personalInfo"),
+    );
+    final wisPerEncCookie = cookies.where((c) => c.name == "WIS_PER_ENC").firstOrNull;
+    if (wisPerEncCookie == null) {
+      throw const RecheckFailedException("WIS_PER_ENC cookie not found");
+    }
+    final keyBytes = Uint8List.fromList(utf8.encode(wisPerEncCookie.value));
+
+    // 4. Encrypt password
+    final encryptedPwd = IdsCrypto.encryptPassword(password, keyBytes);
+
+    // 5. Submit recheck
+    final resp = await dioNoOfflineCheck.post(
+      "https://ids.xidian.edu.cn/personalInfo/common/reCheckPwd",
+      data: {"captcha": captchaCode, "password": encryptedPwd},
+      options: Options(contentType: "application/json"),
+    );
+
+    final data = resp.data;
+    if (data is! Map) {
+      throw RecheckFailedException("响应格式异常");
+    }
+    final code = data["code"];
+    if (code.toString() != "0") {
+      final msg = data["message"] ?? "验证失败";
+      throw RecheckFailedException(msg);
+    }
+    final datas = data["datas"];
+    if (datas is! Map) {
+      throw RecheckFailedException("验证响应数据异常");
+    }
+    return datas["sign"];
+  }
+
+  String _randomN() {
+    return (DateTime.now().millisecondsSinceEpoch / 1000).toStringAsFixed(17);
+  }
+
+  /// Delete a FIDO device credential from the server.
+  ///
+  /// Requires recheck (secondary verification) to have been completed.
+  /// The REFERERCE_TOKEN cookie is used as the referertoken header.
+  Future<void> deleteDevice({
+    required String credentialId,
+    required String username,
+  }) async {
+    // Read REFERERCE_TOKEN cookie for the referertoken header
+    final cookies = await cookieJar.loadForRequest(
+      Uri.parse("https://ids.xidian.edu.cn/personalInfo"),
+    );
+    final refToken = cookies
+        .where((c) => c.name == "REFERERCE_TOKEN")
+        .firstOrNull
+        ?.value;
+
+    final headers = <String, String>{
+      "X-Requested-With": "XMLHttpRequest",
+      "Origin": "https://ids.xidian.edu.cn",
+      "Referer": "https://ids.xidian.edu.cn/personalInfo/personCenter/index.html",
+    };
+    if (refToken != null) {
+      headers["referertoken"] = refToken;
+    }
+
+    final resp = await dioNoOfflineCheck.post(
+      "https://ids.xidian.edu.cn/personalInfo/accountSecurity/deleteDevice",
+      data: {
+        "id": credentialId,
+        "response": username,
+        "n": _randomN(),
+      },
+      options: Options(
+        contentType: "application/json",
+        headers: headers,
+      ),
+    );
+
+    final data = resp.data;
+    if (data is! Map || data["code"].toString() != "0") {
+      throw RecheckFailedException(
+        "删除设备失败: ${data is Map ? data["message"] : "响应格式异常"}",
+      );
+    }
+  }
+}
+
+class RecheckCancelledException implements Exception {}
+
+class RecheckFailedException implements Exception {
+  final String msg;
+  const RecheckFailedException(this.msg);
+  @override
+  String toString() => msg;
+}

--- a/lib/repository/xidian_ids/ids_recheck.dart
+++ b/lib/repository/xidian_ids/ids_recheck.dart
@@ -138,16 +138,16 @@ class IdsRecheck extends IDSSession {
 
     final data = resp.data;
     if (data is! Map) {
-      throw RecheckFailedException("响应格式异常");
+      throw RecheckFailedException("Unexpected response format");
     }
     final code = data["code"];
     if (code.toString() != "0") {
-      final msg = data["message"] ?? "验证失败";
+      final msg = data["message"] ?? "Verification failed";
       throw RecheckFailedException(msg);
     }
     final datas = data["datas"];
     if (datas is! Map) {
-      throw RecheckFailedException("验证响应数据异常");
+      throw RecheckFailedException("Unexpected response data");
     }
     return datas["sign"];
   }
@@ -198,7 +198,7 @@ class IdsRecheck extends IDSSession {
     final data = resp.data;
     if (data is! Map || data["code"].toString() != "0") {
       throw RecheckFailedException(
-        "删除设备失败: ${data is Map ? data["message"] : "响应格式异常"}",
+        "Delete device failed: ${data is Map ? data["message"] : "unexpected response format"}",
       );
     }
   }

--- a/lib/repository/xidian_ids/ids_recheck.dart
+++ b/lib/repository/xidian_ids/ids_recheck.dart
@@ -60,7 +60,7 @@ class IdsRecheck extends IDSSession {
         return data["datas"]["necessary"] == true;
       }
     }
-    return false;
+    return true;
   }
 
   /// Get available recheck approach.

--- a/lib/repository/xidian_ids/ids_session.dart
+++ b/lib/repository/xidian_ids/ids_session.dart
@@ -15,6 +15,7 @@ import 'package:watermeter/page/login/jc_captcha.dart';
 import 'package:watermeter/repository/logger.dart';
 import 'package:watermeter/repository/network_session.dart';
 import 'package:watermeter/repository/preference.dart' as preference;
+import 'package:watermeter/repository/xidian_ids/fido_session.dart';
 
 enum IDSLoginState {
   none,
@@ -118,6 +119,22 @@ class IDSSession extends NetworkSession {
         "[IDSSession][checkAndLogin] "
         "Ready to get $target.",
       );
+
+      // Try FIDO login first if enabled
+      if (preference.getBool(preference.Preference.fidoEnabled)) {
+        try {
+          log.info("[IDSSession][checkAndLogin] Trying FIDO login first.");
+          final fido = FidoSession();
+          final location = await fido.fidoLogin(target: target);
+          loginState = IDSLoginState.success;
+          log.info("[IDSSession][checkAndLogin] FIDO login success.");
+          return location;
+        } catch (e) {
+          log.warning("[IDSSession][checkAndLogin] FIDO login failed, falling back: $e");
+          // FIDO failed, continue with password login
+        }
+      }
+
       var data = await dioNoOfflineCheck.get(
         "https://ids.xidian.edu.cn/authserver/login",
         queryParameters: {'service': target},

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -209,6 +209,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "2.1.9"
+  cbor:
+    dependency: "direct main"
+    description:
+      name: cbor
+      sha256: "2c5c37650f0a2d25149f03e748ab7b2857787bde338f95fe947738b80d713da2"
+      url: "https://pub.dev"
+    source: hosted
+    version: "6.5.1"
   characters:
     dependency: transitive
     description:
@@ -621,6 +629,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "5.3.4"
+  hex:
+    dependency: transitive
+    description:
+      name: hex
+      sha256: "4e7cd54e4b59ba026432a6be2dd9d96e4c5205725194997193bf871703b82c4a"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.2.0"
   home_widget:
     dependency: "direct main"
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -11,6 +11,7 @@ dependencies:
   crypto: ^3.0.6
   pointycastle: ^4.0.0
   encrypter_plus: ^5.1.0
+  cbor: ^6.0.0
   talker_flutter: ^5.0.0
   talker_dio_logger: ^5.0.0
   synchronized: ^3.1.0+1


### PR DESCRIPTION
## Changes

- FIDO registration: generate P-256 key pair, build CBOR attestation, register with IDS server via /personalInfo/accountSecurity endpoints
- FIDO login: assertion-based authentication via /authserver/startAssertion and form submission, bypassing password + captcha flow
- IDS recheck: secondary verification (password + captcha) for sensitive operations like FIDO registration and device deletion
- Login window: FIDO quick login button, post-login prompt to register FIDO as backup login method
- Settings: FIDO registration/deletion UI with server-side credential cleanup
- i18n: FIDO-related strings in zh_CN, en_US, zh_TW
- Dependencies: added pointycastle, cbor, device_info_plus 

**FIDO认证器注册**：
<img width="1600" height="1264" alt="image" src="https://github.com/user-attachments/assets/4d1d92d2-49e5-4288-85a4-52627100c42e" />

**优先使用FIDO凭据进行登录**：
<img width="1576" height="570" alt="image" src="https://github.com/user-attachments/assets/3acc518a-8ab2-45db-8714-ab52b15da35d" />

**FIDO登录流程**：
<img width="1444" height="1882" alt="image" src="https://github.com/user-attachments/assets/af7815a8-3f10-4494-ba66-7356294f58ad" />