### PR TITLE
fix: 修复睿思模块帖子详情返回跳级问题

### DIFF
--- a/lib/external/ruisi_flutter/pages/forum_topics_page.dart
+++ b/lib/external/ruisi_flutter/pages/forum_topics_page.dart
@@ -82,7 +82,7 @@ class _ForumTopicsPageState extends State<ForumTopicsPage> {
           return TopicListItem(
             topic: topic,
             onTap: () =>
-                context.pushReplacement(TopicDetailPage(tid: topic.tid)),
+                context.push(TopicDetailPage(tid: topic.tid)),
           );
         },
       ),

--- a/lib/external/ruisi_flutter/pages/home_page.dart
+++ b/lib/external/ruisi_flutter/pages/home_page.dart
@@ -168,7 +168,7 @@ class _HomePageState extends State<HomePage>
           return TopicListItem(
             topic: topic,
             onTap: () =>
-                context.pushReplacement(TopicDetailPage(tid: topic.tid)),
+                context.push(TopicDetailPage(tid: topic.tid)),
           );
         },
       ),

--- a/lib/external/ruisi_flutter/pages/search_page.dart
+++ b/lib/external/ruisi_flutter/pages/search_page.dart
@@ -96,7 +96,7 @@ class _SearchPageState extends State<SearchPage> {
                   final topic = c.searchResults.value[i];
                   return TopicListItem(
                     topic: topic,
-                    onTap: () => context.pushReplacement(
+                    onTap: () => context.push(
                       TopicDetailPage(tid: topic.tid),
                     ),
                   );


### PR DESCRIPTION
将帖子点击的 pushReplacement 改为 push，修复在 BasedSplitView 架构下返回时跳过中间页面的问题。

修改文件：
- lib/external/ruisi_flutter/pages/home_page.dart
- lib/external/ruisi_flutter/pages/forum_topics_page.dart
- lib/external/ruisi_flutter/pages/search_page.dart