### PR TITLE
fix: 修复Ruisi首页入口在分屏模式下的导航返回异常

### DIFF
--- a/lib/external/ruisi_flutter/pages/home_page.dart
+++ b/lib/external/ruisi_flutter/pages/home_page.dart
@@ -7,6 +7,7 @@ import 'package:signals/signals_flutter.dart';
 import 'package:watermeter/page/public_widget/context_extension.dart';
 
 import '../controller/ruisi_controller.dart';
+import '../utils/branch_navigation.dart';
 import '../widgets/topic_list_item.dart';
 import 'topic_detail_page.dart';
 import '../constants/urls.dart';
@@ -60,12 +61,12 @@ class _HomePageState extends State<HomePage>
             IconButton(
               icon: const Icon(Icons.edit_note),
               tooltip: FlutterI18n.translate(context, 'ruisi.home.new_post'),
-              onPressed: () => context.push(const NewPostPage()),
+              onPressed: () => context.pushRuisiBranch(const NewPostPage()),
             ),
             IconButton(
               icon: const Icon(Icons.forum),
               tooltip: FlutterI18n.translate(context, 'ruisi.home.forum_list'),
-              onPressed: () => context.push(const ForumListPage()),
+              onPressed: () => context.pushRuisiBranch(const ForumListPage()),
             ),
             _buildUserButton(context, c),
           ],
@@ -197,8 +198,7 @@ class _HomePageState extends State<HomePage>
           final topic = topics[i];
           return TopicListItem(
             topic: topic,
-            onTap: () =>
-                context.pushReplacement(TopicDetailPage(tid: topic.tid)),
+            onTap: () => context.pushRuisiBranch(TopicDetailPage(tid: topic.tid)),
           );
         },
       ),
@@ -210,7 +210,7 @@ class _HomePageState extends State<HomePage>
       return IconButton(
         icon: const Icon(Icons.person_outline),
         tooltip: FlutterI18n.translate(context, 'ruisi.common.login'),
-        onPressed: () => context.push(const LoginPage()),
+        onPressed: () => context.pushRuisiBranch(const LoginPage()),
       );
     }
 
@@ -225,7 +225,7 @@ class _HomePageState extends State<HomePage>
         ),
       ),
       tooltip: FlutterI18n.translate(context, 'ruisi.home.my_profile'),
-      onPressed: () => context.push(const UserPage()),
+      onPressed: () => context.pushRuisiBranch(const UserPage()),
     );
   }
 }

--- a/lib/external/ruisi_flutter/utils/branch_navigation.dart
+++ b/lib/external/ruisi_flutter/utils/branch_navigation.dart
@@ -1,0 +1,19 @@
+// Copyright 2026 BenderBlog Rodriguez and Contributors.
+// SPDX-License-Identifier: BSD-3-Clause
+
+import 'package:flutter/material.dart';
+import 'package:watermeter/repository/preference.dart';
+
+extension RuisiBranchNavigation on BuildContext {
+  /// 从 Ruisi 主入口打开一条新的页面分支。
+  ///
+  /// 在分屏模式下会替换右侧当前历史，
+  /// 在单栏模式下会保留根页并打开新的顶层页面。
+  Future<T?> pushRuisiBranch<T extends Object?>(Widget page) {
+    final navigator = splitViewKey.currentState ?? Navigator.of(this);
+    return navigator.pushAndRemoveUntil(
+      MaterialPageRoute<T>(builder: (_) => page),
+      (route) => route.isFirst && route.isActive,
+    );
+  }
+}


### PR DESCRIPTION
## 说明

修复 Ruisi 在分屏模式下首页顶层入口的导航返回异常。

## 变更内容

- 为 Ruisi 首页入口新增独立的分支导航封装
- 将首页的顶层入口改为以“新分支”方式打开右侧内容
- 避免分屏模式下右侧残留旧历史，导致返回路径异常
- 不影响“论坛版块 -> 帖子列表 -> 帖子详情”这条逐级返回链路

## 影响范围

仅涉及 Ruisi 模块：

- `lib/external/ruisi_flutter/pages/home_page.dart`
- `lib/external/ruisi_flutter/utils/branch_navigation.dart`