### PR TITLE
feat: 为 Android 侧 Widget 添加交互，为日程添加 deep link 支持

### DIFF
--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -22,9 +22,15 @@
                  to determine the Window background behind the Flutter UI. -->
             <meta-data android:name="io.flutter.embedding.android.NormalTheme"
                 android:resource="@style/NormalTheme" />
+            <meta-data
+                android:name="flutter_deeplinking_enabled"
+                android:value="false" />
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />
                 <category android:name="android.intent.category.LAUNCHER" />
+            </intent-filter>
+            <intent-filter>
+                <action android:name="es.antonborri.home_widget.action.LAUNCH" />
             </intent-filter>
         </activity>
 

--- a/android/app/src/main/kotlin/io/github/benderblog/traintime_pda/model/ClassTableModels.kt
+++ b/android/app/src/main/kotlin/io/github/benderblog/traintime_pda/model/ClassTableModels.kt
@@ -67,6 +67,11 @@ data class TimeLineItem(
     val startTime: LocalDateTime,
     val endTime: LocalDateTime,
     val colorIndex: Int,
+    val sourceIndex: Int? = null,
+    val weekIndex: Int? = null,
+    val dayIndex: Int? = null,
+    val startPeriod: Int? = null,
+    val stopPeriod: Int? = null,
 ) {
     val startTimeStr: String = when (type) {
         Source.EXAM -> "考"

--- a/android/app/src/main/kotlin/io/github/benderblog/traintime_pda/widget/classtable/ClassTableWidget.kt
+++ b/android/app/src/main/kotlin/io/github/benderblog/traintime_pda/widget/classtable/ClassTableWidget.kt
@@ -6,7 +6,9 @@ package io.github.benderblog.traintime_pda.widget.classtable
 
 import es.antonborri.home_widget.HomeWidgetGlanceState
 import es.antonborri.home_widget.HomeWidgetGlanceStateDefinition
+import es.antonborri.home_widget.actionStartActivity
 import android.content.Context
+import android.net.Uri
 import android.util.Log
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
@@ -65,6 +67,7 @@ import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
 import java.time.LocalDateTime
 import java.time.format.DateTimeFormatter
+import io.github.benderblog.traintime_pda.MainActivity
 
 class ClassTableWidget : GlanceAppWidget() {
     override val stateDefinition: GlanceStateDefinition<*>
@@ -98,6 +101,31 @@ class ClassTableWidget : GlanceAppWidget() {
             "#9CCC65",
             "#66BB6A",
         ).map { it.toColorInt() }
+
+        private fun classTableUri(item: TimeLineItem? = null): String {
+            val builder = Uri.Builder()
+                .scheme("xdyou")
+                .authority("classtable")
+
+            if (item != null) {
+                fun appendOptional(name: String, value: String?) {
+                    if (value != null) builder.appendQueryParameter(name, value)
+                }
+
+                builder.appendQueryParameter("source", item.type.name.lowercase())
+                appendOptional("index", item.sourceIndex?.toString())
+                appendOptional("week", item.weekIndex?.toString())
+                appendOptional("day", item.dayIndex?.toString())
+                builder.appendQueryParameter("start", item.startTime.toString())
+                builder.appendQueryParameter("end", item.endTime.toString())
+                appendOptional("startPeriod", item.startPeriod?.toString())
+                appendOptional("stopPeriod", item.stopPeriod?.toString())
+                builder.appendQueryParameter("name", item.name)
+                builder.appendQueryParameter("place", item.place)
+            }
+
+            return builder.build().toString()
+        }
     }
 
     override suspend fun onDelete(context: Context, glanceId: GlanceId) {
@@ -202,7 +230,16 @@ class ClassTableWidget : GlanceAppWidget() {
                         modifier = GlanceModifier.fillMaxWidth().padding(top = 4.dp),
                         verticalAlignment = Alignment.Vertical.CenterVertically,
                     ) {
-                        Column(modifier = GlanceModifier.defaultWeight().padding(vertical = 4.dp)) {
+                        Column(
+                            modifier = GlanceModifier.defaultWeight()
+                                .clickable(
+                                    onClick = actionStartActivity<MainActivity>(
+                                        context,
+                                        Uri.parse(classTableUri())
+                                    )
+                                )
+                                .padding(vertical = 4.dp)
+                        ) {
                             Text(
                                 context.getString(R.string.widget_classtable_title),
                                 style = TextStyle(
@@ -360,11 +397,19 @@ class ClassTableWidget : GlanceAppWidget() {
 
     @Composable
     private fun ScheduleRow(item: TimeLineItem) {
+        val context = LocalContext.current
         val color = Color(indicatorColorList[item.colorIndex % indicatorColorList.size])
         val colorProvider = ColorProvider(color, color)
 
         Row(
-            modifier = GlanceModifier.fillMaxSize().padding(6.dp).cornerRadius(8.dp)
+            modifier = GlanceModifier.fillMaxSize()
+                .clickable(
+                    onClick = actionStartActivity<MainActivity>(
+                        context,
+                        Uri.parse(classTableUri(item))
+                    )
+                )
+                .padding(6.dp).cornerRadius(8.dp)
                 .background(color.copy(alpha = 0.15f)),
             verticalAlignment = Alignment.Vertical.CenterVertically
         ) {

--- a/android/app/src/main/kotlin/io/github/benderblog/traintime_pda/widget/classtable/ClassTableWidgetDataProvider.kt
+++ b/android/app/src/main/kotlin/io/github/benderblog/traintime_pda/widget/classtable/ClassTableWidgetDataProvider.kt
@@ -302,7 +302,7 @@ class ClassTableWidgetDataProvider {
 
                     timeLineItem.add(
                         TimeLineItem(
-                            type = Source.SCHOOL,
+                            type = arrangement.source,
                             name = classTableData.getClassName(arrangement),
                             teacher = arrangement.teacher ?: "未知教师",
                             place = arrangement.classroom ?: "未安排教室",
@@ -310,7 +310,12 @@ class ClassTableWidgetDataProvider {
                                 .withMinute(startTimePoints[1]).withSecond(0).withNano(0),
                             endTime = now.withHour(endTimePoints[0]).withMinute(endTimePoints[1])
                                 .withSecond(0).withNano(0),
-                            colorIndex = arrangement.index
+                            colorIndex = arrangement.index,
+                            sourceIndex = arrangement.index,
+                            weekIndex = weekIndex,
+                            dayIndex = dayIndex,
+                            startPeriod = arrangement.start,
+                            stopPeriod = arrangement.stop,
                         )
                     )
                 }
@@ -356,7 +361,10 @@ class ClassTableWidgetDataProvider {
                         place = subject.place,
                         startTime = startTime,
                         endTime = endTime,
-                        colorIndex = examData.subject.indexOf(subject)
+                        colorIndex = examData.subject.indexOf(subject),
+                        sourceIndex = examData.subject.indexOf(subject),
+                        weekIndex = weekIndex,
+                        dayIndex = dayIndex,
                     )
                 )
             } else {
@@ -392,6 +400,9 @@ class ClassTableWidgetDataProvider {
                             startTime = timeRange.first,
                             endTime = timeRange.second,
                             colorIndex = experimentData.indexOf(data),
+                            sourceIndex = experimentData.indexOf(data),
+                            weekIndex = weekIndex,
+                            dayIndex = dayIndex,
                         )
                     )
                 } else {

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -314,6 +314,21 @@ class _MyAppState extends State<MyApp> {
           style: const TextStyle(textBaseline: TextBaseline.ideographic),
           child: widget.isFirst ? const LoginWindow() : const HomePage(),
         ),
+        onGenerateRoute: (settings) {
+          final uri = Uri.tryParse(settings.name ?? "");
+          if (uri != null &&
+              uri.path == "/" &&
+              uri.queryParameters.containsKey("source")) {
+            return MaterialPageRoute<void>(
+              settings: settings,
+              builder: (_) => DefaultTextStyle.merge(
+                style: const TextStyle(textBaseline: TextBaseline.ideographic),
+                child: widget.isFirst ? const LoginWindow() : const HomePage(),
+              ),
+            );
+          }
+          return null;
+        },
         builder: (context, widget) {
           Catcher2.addDefaultErrorWidget(
             showStacktrace: true,

--- a/lib/page/classtable/class_page/classtable_page.dart
+++ b/lib/page/classtable/class_page/classtable_page.dart
@@ -1,10 +1,12 @@
 import 'package:flutter/material.dart';
 import 'package:watermeter/page/classtable/class_page/content_classtable_page.dart';
 import 'package:watermeter/page/classtable/class_page/empty_classtable_page.dart';
+import 'package:watermeter/page/classtable/classtable_launch_target.dart';
 import 'package:watermeter/page/classtable/classtable_state.dart';
 
 class ClassTablePage extends StatefulWidget {
-  const ClassTablePage({super.key});
+  final ClassTableLaunchTarget? launchTarget;
+  const ClassTablePage({super.key, this.launchTarget});
 
   @override
   State<ClassTablePage> createState() => _ClassTablePageState();
@@ -37,7 +39,7 @@ class _ClassTablePageState extends State<ClassTablePage> {
   @override
   Widget build(BuildContext context) {
     return classTableState.haveClass
-        ? const ContentClassTablePage()
+        ? ContentClassTablePage(launchTarget: widget.launchTarget)
         : const EmptyClassTablePage();
   }
 }

--- a/lib/page/classtable/class_page/content_classtable_page.dart
+++ b/lib/page/classtable/class_page/content_classtable_page.dart
@@ -2,6 +2,7 @@
 // Copyright 2025 Traintime PDA authors.
 // SPDX-License-Identifier: MPL-2.0 OR Apache-2.0
 
+import 'dart:async';
 import 'dart:io';
 import 'dart:typed_data';
 
@@ -12,22 +13,29 @@ import 'package:intl/intl.dart';
 
 import 'package:styled_widget/styled_widget.dart';
 import 'package:watermeter/model/xidian_ids/classtable.dart';
+import 'package:watermeter/model/xidian_ids/exam.dart';
+import 'package:watermeter/model/xidian_ids/experiment.dart';
+import 'package:watermeter/page/classtable/arrangement_detail/arrangement_detail.dart';
 import 'package:watermeter/page/classtable/class_add/class_add_window.dart';
 import 'package:watermeter/page/classtable/class_page/class_change_list.dart';
 import 'package:watermeter/page/classtable/class_page/classtable_inline_banner.dart';
 import 'package:watermeter/page/classtable/class_table_view/class_table_view.dart';
+import 'package:watermeter/page/classtable/class_table_view/class_organized_data.dart';
 import 'package:watermeter/page/classtable/class_table_view/completed_class_style.dart';
 import 'package:watermeter/page/classtable/class_table_view/current_time_indicator.dart';
+import 'package:watermeter/page/classtable/classtable_launch_target.dart';
 import 'package:watermeter/page/classtable/classtable_constant.dart';
 import 'package:watermeter/page/classtable/classtable_state.dart';
 import 'package:watermeter/page/classtable/class_page/not_arranged_class_list.dart';
 import 'package:watermeter/page/classtable/class_page/week_choice_view.dart';
+import 'package:watermeter/page/public_widget/both_side_sheet.dart';
 import 'package:watermeter/page/public_widget/toast.dart';
 import 'package:watermeter/repository/network_session.dart';
 import 'package:watermeter/repository/preference.dart' as preference;
 
 class ContentClassTablePage extends StatefulWidget {
-  const ContentClassTablePage({super.key});
+  final ClassTableLaunchTarget? launchTarget;
+  const ContentClassTablePage({super.key, this.launchTarget});
 
   @override
   State<StatefulWidget> createState() => _ContentClassTablePageState();
@@ -51,6 +59,7 @@ class _ContentClassTablePageState extends State<ContentClassTablePage> {
   late ClassTableWidgetState classTableState;
   bool _isListening = false;
   bool _didLoadVisualSettings = false;
+  bool _didHandleLaunchTarget = false;
 
   void _switchPage() {
     if (!mounted) {
@@ -73,6 +82,146 @@ class _ContentClassTablePageState extends State<ContentClassTablePage> {
         isTopRowLocked = false;
       }
     });
+  }
+
+  bool _sameMinute(DateTime? a, DateTime? b) {
+    if (a == null || b == null) return false;
+    return a.year == b.year &&
+        a.month == b.month &&
+        a.day == b.day &&
+        a.hour == b.hour &&
+        a.minute == b.minute;
+  }
+
+  bool _matchesLaunchTarget(
+    ClassOrgainzedData event,
+    ClassTableLaunchTarget target,
+  ) {
+    final source = target.source;
+    if (source == null) return false;
+
+    for (final data in event.data) {
+      if (data is TimeArrangement) {
+        if (source != data.source.name.toLowerCase()) continue;
+        if (target.index != null && target.index != data.index) continue;
+        if (target.dayIndex != null && target.dayIndex != data.day) continue;
+        if (target.startPeriod != null && target.startPeriod != data.start) {
+          continue;
+        }
+        if (target.stopPeriod != null && target.stopPeriod != data.stop) {
+          continue;
+        }
+        if (target.weekIndex != null &&
+            (data.weekList.length <= target.weekIndex! ||
+                !data.weekList[target.weekIndex!])) {
+          continue;
+        }
+        return true;
+      }
+
+      if (data is Subject && source == "exam") {
+        final index = classTableState.subjects.indexOf(data);
+        if (target.index != null && target.index != index) continue;
+        if (!_sameMinute(data.startTime, target.startTime)) continue;
+        return true;
+      }
+
+      if (data is ExperimentData && source == "experiment") {
+        final index = classTableState.experiments.indexOf(data);
+        if (target.index != null && target.index != index) continue;
+        if (target.startTime == null) return true;
+        final matchesTimeRange = data.timeRanges.any(
+          (range) =>
+              _sameMinute(range.$1, target.startTime) &&
+              _sameMinute(range.$2, target.endTime),
+        );
+        if (matchesTimeRange) return true;
+      }
+    }
+
+    return false;
+  }
+
+  List<dynamic> _buildArrangementInformation(ClassOrgainzedData detail) {
+    return List.generate(detail.data.length, (index) {
+      final data = detail.data.elementAt(index);
+      if (data is Subject || data is ExperimentData) {
+        return data;
+      }
+
+      final arrangement = data as TimeArrangement;
+      return (
+        classTableState.getClassDetail(
+          classTableState.timeArrangement.indexOf(arrangement),
+        ),
+        arrangement,
+      );
+    });
+  }
+
+  Future<void> _showArrangementDetail(ClassOrgainzedData detail) async {
+    final toUse = await BothSideSheet.show<(ClassDetail, TimeArrangement, bool)>(
+      title: FlutterI18n.translate(context, "classtable.class_card.title"),
+      child: ArrangementDetail(
+        information: _buildArrangementInformation(detail),
+        currentWeek: classTableState.chosenWeek,
+      ),
+      context: context,
+    );
+
+    if (!context.mounted || toUse == null) return;
+    if (toUse.$3) {
+      await classTableState.deleteUserDefinedClass(toUse.$2);
+      return;
+    }
+
+    await Navigator.of(context)
+        .push(
+          MaterialPageRoute(
+            builder: (context) => ClassAddWindow(
+              toChange: (toUse.$1, toUse.$2),
+              semesterLength: classTableState.semesterLength,
+            ),
+          ),
+        )
+        .then((value) {
+          if (value == null) return;
+          classTableState.editUserDefinedClass(value.$1, value.$2, value.$3);
+        });
+  }
+
+  Future<void> _handleLaunchTarget() async {
+    final target = widget.launchTarget;
+    if (_didHandleLaunchTarget || target == null) return;
+    _didHandleLaunchTarget = true;
+
+    final weekIndex = target.weekIndex;
+    if (weekIndex != null &&
+        weekIndex >= 0 &&
+        weekIndex < classTableState.semesterLength) {
+      classTableState.chosenWeek = weekIndex;
+    }
+
+    if (!target.opensSchedule) return;
+
+    final dayIndex = target.dayIndex;
+    if (weekIndex == null || dayIndex == null) return;
+
+    final arrangements = classTableState.getArrangement(
+      weekIndex: weekIndex,
+      dayIndex: dayIndex,
+    );
+    ClassOrgainzedData? match;
+    for (final event in arrangements) {
+      if (_matchesLaunchTarget(event, target)) {
+        match = event;
+        break;
+      }
+    }
+
+    if (match != null && mounted) {
+      await _showArrangementDetail(match);
+    }
   }
 
   @override
@@ -127,6 +276,10 @@ class _ContentClassTablePageState extends State<ContentClassTablePage> {
           : null,
     );
     super.didChangeDependencies();
+
+    WidgetsBinding.instance.addPostFrameCallback((_) {
+      if (mounted) unawaited(_handleLaunchTarget());
+    });
   }
 
   /// A row shows a series of buttons about the classtable's index.

--- a/lib/page/classtable/classtable.dart
+++ b/lib/page/classtable/classtable.dart
@@ -4,12 +4,18 @@
 
 import 'package:flutter/material.dart';
 import 'package:watermeter/page/classtable/class_page/classtable_page.dart';
+import 'package:watermeter/page/classtable/classtable_launch_target.dart';
 import 'package:watermeter/page/classtable/classtable_state.dart';
 
 /// Intro of the classtable.
 class ClassTableWindow extends StatefulWidget {
   final BoxConstraints constraints;
-  const ClassTableWindow({super.key, required this.constraints});
+  final ClassTableLaunchTarget? launchTarget;
+  const ClassTableWindow({
+    super.key,
+    required this.constraints,
+    this.launchTarget,
+  });
 
   @override
   State<ClassTableWindow> createState() => _ClassTableWindowState();
@@ -35,7 +41,7 @@ class _ClassTableWindowState extends State<ClassTableWindow> {
     return ClassTableState(
       constraints: widget.constraints,
       controllers: _controllers,
-      child: const ClassTablePage(),
+      child: ClassTablePage(launchTarget: widget.launchTarget),
     );
   }
 }

--- a/lib/page/classtable/classtable_launch_target.dart
+++ b/lib/page/classtable/classtable_launch_target.dart
@@ -1,0 +1,50 @@
+// Copyright 2023-2025 BenderBlog Rodriguez and contributors
+// Copyright 2025 Traintime PDA authors.
+// SPDX-License-Identifier: MPL-2.0
+
+class ClassTableLaunchTarget {
+  final String? source;
+  final int? index;
+  final int? weekIndex;
+  final int? dayIndex;
+  final DateTime? startTime;
+  final DateTime? endTime;
+  final int? startPeriod;
+  final int? stopPeriod;
+  final String? name;
+  final String? place;
+
+  const ClassTableLaunchTarget({
+    this.source,
+    this.index,
+    this.weekIndex,
+    this.dayIndex,
+    this.startTime,
+    this.endTime,
+    this.startPeriod,
+    this.stopPeriod,
+    this.name,
+    this.place,
+  });
+
+  bool get opensSchedule => source != null;
+
+  static ClassTableLaunchTarget? fromUri(Uri? uri) {
+    if (uri == null) return null;
+    if (uri.scheme != "xdyou" || uri.host != "classtable") return null;
+
+    final params = uri.queryParameters;
+    return ClassTableLaunchTarget(
+      source: params["source"],
+      index: int.tryParse(params["index"] ?? ""),
+      weekIndex: int.tryParse(params["week"] ?? ""),
+      dayIndex: int.tryParse(params["day"] ?? ""),
+      startTime: DateTime.tryParse(params["start"] ?? ""),
+      endTime: DateTime.tryParse(params["end"] ?? ""),
+      startPeriod: int.tryParse(params["startPeriod"] ?? ""),
+      stopPeriod: int.tryParse(params["stopPeriod"] ?? ""),
+      name: params["name"],
+      place: params["place"],
+    );
+  }
+}

--- a/lib/page/homepage/home.dart
+++ b/lib/page/homepage/home.dart
@@ -9,6 +9,7 @@ import 'dart:async';
 import 'package:based_split_view/based_split_view.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_i18n/flutter_i18n.dart';
+import 'package:home_widget/home_widget.dart';
 import 'package:watermeter/external/ruisi_flutter/controller/ruisi_controller.dart';
 import 'package:watermeter/external/ruisi_flutter/ruisi_main.dart';
 import 'package:watermeter/page/pig/pig_page.dart';
@@ -17,6 +18,7 @@ import 'package:watermeter/repository/logger.dart';
 import 'package:watermeter/page/public_widget/toast.dart';
 import 'package:restart_app/restart_app.dart';
 import 'package:watermeter/repository/widget_state_sync.dart';
+import 'package:watermeter/repository/widget_launch_handler.dart';
 import 'package:watermeter/controller/update_notice_controller.dart';
 import 'package:watermeter/page/homepage/homepage.dart';
 import 'package:watermeter/page/homepage/refresh.dart';
@@ -66,7 +68,7 @@ class _HomePageMasterState extends State<HomePageMaster>
   int _selectedIndex = 0;
   static bool refreshAtStart = false;
 
-  late StreamSubscription _intentSub;
+  StreamSubscription<Uri?>? _intentSub;
   late PageController _controller;
 
   @override
@@ -74,6 +76,18 @@ class _HomePageMasterState extends State<HomePageMaster>
     super.initState();
     _controller = PageController();
     RuisiController.i.init();
+    if (Platform.isAndroid || Platform.isIOS) {
+      _intentSub = HomeWidget.widgetClicked.listen((uri) {
+        if (mounted) unawaited(handleWidgetLaunchUri(context, uri));
+      });
+      WidgetsBinding.instance.addPostFrameCallback((_) async {
+        if (!mounted) return;
+        await handleWidgetLaunchUri(
+          context,
+          await HomeWidget.initiallyLaunchedFromHomeWidget(),
+        );
+      });
+    }
   }
 
   void _loginAsync() async {
@@ -216,7 +230,7 @@ class _HomePageMasterState extends State<HomePageMaster>
 
   @override
   void dispose() {
-    if (Platform.isAndroid || Platform.isIOS) _intentSub.cancel();
+    _intentSub?.cancel();
     WidgetsBinding.instance.removeObserver(this);
     super.dispose();
   }

--- a/lib/repository/widget_launch_handler.dart
+++ b/lib/repository/widget_launch_handler.dart
@@ -1,0 +1,18 @@
+// Copyright 2023-2025 BenderBlog Rodriguez and contributors
+// Copyright 2025 Traintime PDA authors.
+// SPDX-License-Identifier: MPL-2.0
+
+import 'package:flutter/widgets.dart';
+import 'package:watermeter/page/classtable/classtable_launch_target.dart';
+import 'package:watermeter/page/public_widget/context_extension.dart';
+import 'package:watermeter/routing/routes.dart';
+
+Future<void> handleWidgetLaunchUri(BuildContext context, Uri? uri) async {
+  final target = ClassTableLaunchTarget.fromUri(uri);
+  if (target == null || !context.mounted) return;
+
+  await context.pushReplacementNamed(
+    Routes.classTable,
+    arguments: target,
+  );
+}

--- a/lib/routing/routes.dart
+++ b/lib/routing/routes.dart
@@ -5,6 +5,7 @@
 import 'package:flutter/material.dart';
 import 'package:watermeter/page/class_attendance/class_attendance_view.dart';
 import 'package:watermeter/page/classtable/classtable.dart';
+import 'package:watermeter/page/classtable/classtable_launch_target.dart';
 import 'package:watermeter/page/dorm_water/dorm_water_window.dart';
 import 'package:watermeter/page/empty_classroom/empty_classroom_window.dart';
 import 'package:watermeter/page/energy/electricity_window.dart';
@@ -42,7 +43,12 @@ class Routes {
       exam => const ExamInfoWindow(),
       classTable => LayoutBuilder(
         builder: (context, constraints) =>
-            ClassTableWindow(constraints: constraints),
+            ClassTableWindow(
+              constraints: constraints,
+              launchTarget: arguments is ClassTableLaunchTarget
+                  ? arguments
+                  : null,
+            ),
       ),
       about => const AboutPage(),
       sport => const SportWindow(),


### PR DESCRIPTION
## 摘要

**该 Pull Request 为 Android 侧日程 Widget 添加点击交互功能，同时为日程引入 deep link 支持。应用现在可以处理来自 Widget（或外部启动）的链接，直接跳转到指定的课程、考试或实验详情页。** 具体地，点击该 Widget 的头部（`XDYou 日程信息`、`M月D日 周X 第 W 周`）会跳转到日程页面；点击该 Widget 的具体日程可以跳转到其详情页面，效果类似于在 app 日程页面点击某一日程后查看详情。

<div align="center">
<img width="318" height="239" alt="Android 侧 Widget" src="https://github.com/user-attachments/assets/e6320f67-34e0-4165-ba8f-f58d7e4e6ef9" />
</div>

## 主要变更

在 Android Widget 侧：零音为 Glance Widget 的头部和日程行添加了点击动作。点击头部后，头部通过内部 URI 直接打开日程页面。点击日程行时，日程行通过携带日程元数据的内部 URI 打开日程页面，日程页面匹配对应日程后打开对应日程。这里，日程元数据包括来源类型、索引、周索引、天索引、开始/结束时间等。为达成这一点，零音为 `TimeLineItem` 扩展了点击定位所需的元数据，同时保留了现有的 今天/明天 切换功能。

在 Flutter 侧：零音添加了 `ClassTableLaunchTarget` 用于解析小部件的启动 URI；添加了一个小部件启动处理器，将有效的小部件 URI 转换为日程页面的导航；将 `HomeWidget.widgetClicked` 和 `HomeWidget.initiallyLaunchedFromHomeWidget()` 连接到主页；通过现有的路由解析器将启动目标数据传递到日程页面。在日程页面，应用首先会进行匹配：如果匹配，则打开详情；否则进入日程页面而非直接失败。

在 Android 清单侧，零音为 `MainActivity` 添加了 `home_widget` 启动意图动作。这里有一个潜在问题，零音不确定自己是否 properly handle 了该问题，将在后文说明。

## 设计说明

Android 小部件是使用 Jetpack Glance 实现的原生 Android 应用小部件。考虑到该项目已经在使用 `home_widget`，故该 PR 力求桥接层精简。具体地：

```
Glance Widget 点击
  -> home_widget 通过 URI 启动 MainActivity
  -> Flutter 从 home_widget 接收 URI
  -> Flutter 将其解析为 ClassTableLaunchTarget
  -> 打开现有的课表路由
  -> 复用现有的安排详情 UI
```

零音不愿引入自定义的平台通道或一套并行的 Android <-> Flutter 导航系统。对于日程详情导航，Widget 不会将 serialized 的完整日程对象传回 Flutter，而是传递相对稳定的标识元数据，让 Flutter 根据自己的当前课表状态匹配。零音预期 Android widget 数据模型的轻量化和交流的简洁，避免跨平台重复完整的详情渲染契约。

考虑到课程安排、考试和实验的数据标识方式不同，因此，所有课程通过来源、索引、周/天 和 节次 范围匹配；考试通过索引和开始时间匹配；实验通过索引和时间范围匹配，因此 Widget 行 URI 同时包含了结构字段和时间字段。

## 潜在问题

该 feature 的引入可能会导致一个潜在问题。具体地，在应用已经打开时回到桌面再点击小部件，Flutter 内置的 deep link 机制会尝试将 Widget 的 URI 解释为普通路由，从而会引发错误

```
Could not find a generator for route RouteSettings("/?source=...", null)
```

<div align="center">
<img width="566" height="697" alt="潜在问题导致的报错" src="https://github.com/user-attachments/assets/5b1d36fe-286f-4eea-95e9-84804088ff79" />
</div>

为了解决这一问题，零音为 `MainActivity` 禁用了 Flutter 的自动 deep link 处理（通过 `meta-data` 设置 `flutter_deeplinking_enabled` 为 `false`），并添加了防御性的 `onGenerateRoute` 回滚，以确保在极为特殊的情况下，若 Widget 路由仍然到达了 Flutter 路由解析器，也不会导致应用崩溃。

但正如前文所说，零音并不确定是否已 properly handle 了此问题。

## 测试

零音在自己的设备上完成了测试，表现符合该 PR 的预期。

## 说明

本 PR 有意将 `xdyou://classtable` 作为内部 Widget 的启动 URI。未在 Android 中注册公开的外部应用链接 scheme，因此该变更不会有意暴露新的公开 deep link URI。即，本 PR 中的 deep link 支持仅用于内部 Widget 交互，并不作为公共 API 对外公开。