### PR TITLE
fix: split captcha client and correct tomorrow schedule

### DIFF
--- a/lib/controller/classtable_controller.dart
+++ b/lib/controller/classtable_controller.dart
@@ -256,7 +256,7 @@ class ClassTableController {
 
   List<HomeArrangement> getArrangementOfDay(DateTime updateTime) {
     final formatter = DateFormat(HomeArrangement.format);
-    final currentWeek = currentWeekComputedSignal.value;
+    final currentWeek = getCurrentWeek(updateTime);
     final classTableData = classTableComputedSignal.value;
     final arrangementSet = <HomeArrangement>{};
 

--- a/lib/page/homepage/home.dart
+++ b/lib/page/homepage/home.dart
@@ -26,6 +26,7 @@ import 'package:watermeter/repository/preference.dart';
 import 'package:watermeter/repository/xidian_ids/ids_session.dart';
 import 'package:ming_cute_icons/ming_cute_icons.dart';
 import 'package:watermeter/page/login/jc_captcha.dart';
+import 'package:watermeter/repository/xidian_ids/slider_captcha_client.dart';
 import 'package:watermeter/repository/preference.dart' as preference;
 
 class PageInformation {
@@ -87,7 +88,10 @@ class _HomePageMasterState extends State<HomePageMaster>
         context: context,
         forceRetryLogin: true,
         sliderCaptcha: (String cookieStr) {
-          return SliderCaptchaClientProvider(cookie: cookieStr).solve(context);
+          return SliderCaptchaClientProvider(cookie: cookieStr).solve(
+            manualSolver: (provider) =>
+                solveSliderCaptchaManually(context, provider),
+          );
         },
       );
     } finally {
@@ -204,9 +208,10 @@ class _HomePageMasterState extends State<HomePageMaster>
           context: context,
           forceRetryLogin: true,
           sliderCaptcha: (String cookieStr) {
-            return SliderCaptchaClientProvider(
-              cookie: cookieStr,
-            ).solve(context);
+            return SliderCaptchaClientProvider(cookie: cookieStr).solve(
+              manualSolver: (provider) =>
+                  solveSliderCaptchaManually(context, provider),
+            );
           },
         );
       }

--- a/lib/page/homepage/homepage.dart
+++ b/lib/page/homepage/homepage.dart
@@ -16,6 +16,7 @@ import 'package:watermeter/page/homepage/refresh.dart';
 import 'package:watermeter/repository/notification/course_reminder_service.dart';
 import 'package:watermeter/repository/logger.dart';
 import 'package:watermeter/page/login/jc_captcha.dart';
+import 'package:watermeter/repository/xidian_ids/slider_captcha_client.dart';
 
 class MainPage extends StatefulWidget {
   final Function()? changePage;
@@ -210,9 +211,10 @@ class _MainPageState extends State<MainPage> with TickerProviderStateMixin {
           await update(
             context: context,
             sliderCaptcha: (String cookieStr) {
-              return SliderCaptchaClientProvider(
-                cookie: cookieStr,
-              ).solve(context);
+              return SliderCaptchaClientProvider(cookie: cookieStr).solve(
+                manualSolver: (provider) =>
+                    solveSliderCaptchaManually(context, provider),
+              );
             },
           );
           if (context.mounted) {

--- a/lib/page/homepage/info_widget/classtable_card.dart
+++ b/lib/page/homepage/info_widget/classtable_card.dart
@@ -70,6 +70,10 @@ class _ClassTableCardState extends State<ClassTableCard> {
                 controller.homepageArrangementStateComputedSignal.value;
             final arrangements = controller.arrangementComputedSignal.value;
             final isTomorrow = controller.isTomorrowComputedSignal.value;
+            final updateTime = controller.updateTimeComputedSignal.value;
+            final displayTime = isTomorrow
+                ? updateTime.add(const Duration(days: 1))
+                : updateTime;
             final isAllSourcesLoading =
                 controller.isAllSourcesLoadingComputedSignal.value;
             final isPartialSourcesLoading =
@@ -78,8 +82,9 @@ class _ClassTableCardState extends State<ClassTableCard> {
             final havePhysicsExperiment =
                 controller.havePhysicsExperimentSignal.value;
             final isPostGraduate = controller.isPostGraduate;
-            final currentWeek =
-                classTableController.currentWeekComputedSignal.value;
+            final currentWeek = classTableController.getCurrentWeek(
+              displayTime,
+            );
             final semesterLength = classTableController
                 .classTableComputedSignal
                 .value
@@ -98,6 +103,7 @@ class _ClassTableCardState extends State<ClassTableCard> {
                 isTomorrow: isTomorrow,
                 emptyInfoText: _getEmptyInfoText(arrangementState),
                 arrangementState: arrangementState,
+                displayTime: displayTime,
                 currentWeek: currentWeek,
                 semesterLength: semesterLength,
               ),
@@ -121,6 +127,7 @@ class _ClassArrangementListView extends StatelessWidget {
   final bool isTomorrow;
   final String emptyInfoText;
   final ArrangementState arrangementState;
+  final DateTime displayTime;
   final int currentWeek;
   final int semesterLength;
 
@@ -129,6 +136,7 @@ class _ClassArrangementListView extends StatelessWidget {
     required this.isTomorrow,
     required this.emptyInfoText,
     required this.arrangementState,
+    required this.displayTime,
     required this.currentWeek,
     required this.semesterLength,
   });
@@ -196,12 +204,12 @@ class _ClassArrangementListView extends StatelessWidget {
                 String timeString = DateFormat(
                   "MMMd",
                   FlutterI18n.currentLocale(context).toString(),
-                ).format(DateTime.now());
+                ).format(displayTime);
 
                 String weekString = DateFormat(
                   "E",
                   FlutterI18n.currentLocale(context).toString(),
-                ).format(DateTime.now());
+                ).format(displayTime);
 
                 String weekInfo =
                     currentWeek >= 0 && currentWeek < semesterLength

--- a/lib/page/login/jc_captcha.dart
+++ b/lib/page/login/jc_captcha.dart
@@ -4,327 +4,25 @@
 
 // https://juejin.cn/post/7284608063914622995
 
-import 'dart:convert';
-import 'dart:io';
 import 'dart:math';
-import 'dart:typed_data';
-import 'package:dio/dio.dart';
+
 import 'package:flutter/material.dart';
 import 'package:flutter_i18n/flutter_i18n.dart';
-import 'package:image/image.dart' as img;
 import 'package:styled_widget/styled_widget.dart';
 import 'package:watermeter/repository/logger.dart';
-import 'package:watermeter/repository/network_session.dart';
+import 'package:watermeter/repository/xidian_ids/slider_captcha_client.dart';
 
-class Lazy<T> {
-  final T Function() _initializer;
-
-  Lazy(this._initializer);
-
-  T? _value;
-
-  T get value => _value ??= _initializer();
-}
-
-/// Finger movement track point
-class TrackPoint {
-  final int a; // x pos
-  final int b; // y pos
-  final int c; // milliseconds
-
-  TrackPoint(this.a, this.b, this.c);
-
-  Map<String, dynamic> toJson() => {'a': a, 'b': b, 'c': c};
-}
-
-class SliderCaptchaClientProvider {
-  final String cookie;
-  Dio dio = Dio()..interceptors.add(logDioAdapter);
-
-  SliderCaptchaClientProvider({required this.cookie});
-
-  final double _puzzleWidth = 280;
-  final double _puzzleHeight = 155;
-  final double _pieceWidth = 44;
-  final double _pieceHeight = 155;
-  Uint8List? _puzzleData;
-  Uint8List? _pieceData;
-  Lazy<Image>? _puzzleImage;
-  Lazy<Image>? _pieceImage;
-  Uint8List? _aesKey;
-
-  // fetch and update captcha data
-  Future<void> updatePuzzle() async {
-    // fetch captcha data
-    log.info("Fetching slider captcha...");
-    var rsp = await dio.get(
-      "https://ids.xidian.edu.cn/authserver/common/openSliderCaptcha.htl",
-      queryParameters: {'_': DateTime.now().millisecondsSinceEpoch.toString()},
-      options: Options(headers: {"Cookie": cookie}),
-    );
-    log.info("Captcha fetched, decoding images.");
-    // decode base64 and extract aes key
-    String puzzleBase64 = rsp.data["bigImage"];
-    String pieceBase64 = rsp.data["smallImage"];
-    _puzzleData = const Base64Decoder().convert(puzzleBase64);
-    _pieceData = const Base64Decoder().convert(pieceBase64);
-    _aesKey = _pieceData!.sublist(_pieceData!.length - 16); // key = last 16B
-    // update images
-    _puzzleImage = Lazy(
-      () => Image.memory(
-        _puzzleData!,
-        width: _puzzleWidth,
-        height: _puzzleHeight,
-        fit: BoxFit.fitWidth,
-      ),
-    );
-    _pieceImage = Lazy(
-      () => Image.memory(
-        _pieceData!,
-        width: _pieceWidth,
-        height: _pieceHeight,
-        fit: BoxFit.fitWidth,
-      ),
-    );
-  }
-
-  // submit and verify captcha
-  Future<bool> verify(List<TrackPoint> tracks) async {
-    final payload = jsonEncode({
-      "canvasLength": _puzzleWidth.toInt(),
-      "moveLength": tracks.isNotEmpty ? tracks.last.a : 0,
-      "tracks": tracks,
-    });
-    final sign = aesEncrypt(payload, _aesKey!);
-    dynamic result = await dio.post(
-      "https://ids.xidian.edu.cn/authserver/common/verifySliderCaptcha.htl",
-      data: "sign=${Uri.encodeQueryComponent(sign)}",
-      options: Options(
-        headers: {
-          HttpHeaders.acceptHeader:
-              "application/json, text/javascript, */*; q=0.01",
-          "Cookie": cookie,
-          HttpHeaders.contentTypeHeader:
-              "application/x-www-form-urlencoded;charset=UTF-8",
-          "Origin": "https://ids.xidian.edu.cn",
-          HttpHeaders.accessControlAllowOriginHeader:
-              "https://ids.xidian.edu.cn",
-          "X-Requested-With": "XMLHttpRequest",
-        },
-      ),
-    );
-    log.info("Tried captcha payload:$payload, result:${result.data}");
-    return result.data["errorCode"] == 1;
-  }
-
-  // solve slider captcha
-  Future<void> solve(BuildContext? context) async {
-    log.info("Solving slider captcha automatically");
-    // multiple tries
-    for (int i = 0; i < 6; ++i) {
-      // refresh captcha
-      await updatePuzzle();
-      final offset = solveOffset(_puzzleData!, _pieceData!);
-      if (offset == null) throw CaptchaSolveFailedException();
-      final int baseMove = (offset * _puzzleWidth).round();
-      // try neighboring moves
-      for (final delta in [1, -1, 2, -2, 3, -3, 4]) {
-        final move = baseMove + delta;
-        if (move < 0 || move > _puzzleWidth.toInt()) continue;
-        final tracks = generateTracks(move);
-        // sleep
-        await Future.delayed(
-          Duration(milliseconds: max(tracks.last.c - 100, 0)),
-        );
-        // verify
-        try {
-          if (await verify(tracks)) return;
-        } catch (_) {}
-      }
-    }
-    // fallback to manual solving
-    log.info("Solving slider captcha manually");
-    if (context != null && context.mounted) {
-      final verified = await Navigator.of(context).push<bool>(
-        MaterialPageRoute(builder: (context) => CaptchaWidget(provider: this)),
-      );
-      if (verified == true) return;
-    }
-    throw CaptchaSolveFailedException();
-  }
-
-  ///
-  /// Slider CAPTCHA offset solver
-  ///
-
-  // match offset with ncc.
-  static double? solveOffset(
-    Uint8List puzzleData,
-    Uint8List pieceData, {
-    int border = 24,
-  }) {
-    img.Image? puzzle = img.decodeImage(puzzleData);
-    if (puzzle == null) return null;
-    img.Image? piece = img.decodeImage(pieceData);
-    if (piece == null) return null;
-    final bbox = _imageBbox(piece);
-    var xL = bbox.$1 + border;
-    var yT = bbox.$2 + border;
-    var xR = bbox.$3 - border;
-    var yB = bbox.$4 - border;
-
-    final windowWidth = xR - xL + 1;
-    final windowHeight = yB - yT + 1;
-    final bigWidth = puzzle.width - piece.width + windowWidth;
-    final templateMean =
-        _imageSum(piece, xL, yT, windowWidth, windowHeight) /
-        (windowWidth * windowHeight);
-    final template = _imageNorm(
-      piece,
-      xL,
-      yT,
-      windowWidth,
-      windowHeight,
-      templateMean,
-    );
-    final columnSums = List<double>.generate(
-      bigWidth,
-      (x) => _imageSum(puzzle, x + xL, yT, 1, windowHeight),
-      growable: false,
-    );
-
-    var windowSum = 0.0;
-    for (var x = 0; x < windowWidth; x++) {
-      windowSum += columnSums[x];
-    }
-    final area = windowWidth * windowHeight;
-    var nccMax = _imageNcc(
-      puzzle,
-      0 + xL,
-      yT,
-      windowWidth,
-      windowHeight,
-      template,
-      windowSum / area,
-    );
-    var xMax = 0;
-    for (var x = 1; x < bigWidth - windowWidth; x++) {
-      windowSum += columnSums[x + windowWidth - 1] - columnSums[x - 1];
-      final ncc = _imageNcc(
-        puzzle,
-        x + xL,
-        yT,
-        windowWidth,
-        windowHeight,
-        template,
-        windowSum / area,
-      );
-      if (ncc > nccMax) {
-        nccMax = ncc;
-        xMax = x;
-      }
-    }
-    return xMax / puzzle.width;
-  }
-
-  // find bbox
-  static (int, int, int, int) _imageBbox(img.Image image) {
-    var xL = image.width, yT = image.height, xR = 0, yB = 0;
-    for (var y = 0; y < image.height; y++) {
-      for (var x = 0; x < image.width; x++) {
-        if (image.getPixel(x, y).a.toInt() == 255) {
-          if (x < xL) xL = x;
-          if (y < yT) yT = y;
-          if (x > xR) xR = x;
-          if (y > yB) yB = y;
-        }
-      }
-    }
-    return (xL, yT, xR, yB);
-  }
-
-  // calculate sum of area in an image
-  static double _imageSum(
-    img.Image image,
-    int xL,
-    int yT,
-    int width,
-    int height,
-  ) {
-    double sum = 0;
-    for (var y = yT; y < yT + height; y++) {
-      for (var x = xL; x < xL + width; x++) {
-        sum += image.getPixel(x, y).luminance;
-      }
-    }
-    return sum;
-  }
-
-  // normalize area in an image
-  static List<double> _imageNorm(
-    img.Image image,
-    int xL,
-    int yT,
-    int width,
-    int height,
-    double mean,
-  ) {
-    return [
-      for (var y = yT; y < yT + height; y++)
-        for (var x = xL; x < xL + width; x++)
-          image.getPixel(x, y).luminance - mean,
-    ];
-  }
-
-  // calculate ncc of area in an image with a template
-  static double _imageNcc(
-    img.Image window,
-    int xL,
-    int yT,
-    int width,
-    int height,
-    List<double> template,
-    double meanW,
-  ) {
-    double sumWt = 0, sumWw = 0.000001;
-    var iT = template.iterator;
-    for (var y = yT; y < yT + height; y++) {
-      for (var x = xL; x < xL + width; x++) {
-        iT.moveNext();
-        var w = window.getPixel(x, y).luminance - meanW;
-        sumWt += w * iT.current;
-        sumWw += w * w;
-      }
-    }
-    return sumWt / sumWw;
-  }
-
-  ///
-  /// Finger move track generation
-  ///
-
-  static final _rng = Random();
-  static final _genTracksNorm = 1.0 / (1.0 + exp(-7.0 * (1.0 - 0.42)));
-
-  // generate track along an skewed sigmoid curve
-  static List<TrackPoint> generateTracks(int offs) {
-    final tracks = <TrackPoint>[TrackPoint(0, 0, 0)];
-    final int n = _rng.nextInt(5) + 10;
-    int b = 0;
-    for (int i = 0; i < n; i++) {
-      // horizontal
-      final double z =
-          (1.0 / (1.0 + exp(-7.0 * ((i / n) - 0.42)))) / _genTracksNorm;
-      final int a = min(offs - 1, max(tracks.last.a + 1, (offs * z).round()));
-      // vertical
-      final double r = _rng.nextDouble();
-      b = ((r < 0.65) ? (b - 1) : ((r < 0.80) ? (b + 1) : (b)));
-      b = max(-10, min(10, b));
-      tracks.add(TrackPoint(a, b, _rng.nextInt(201) + 300));
-    }
-    tracks.add(TrackPoint(offs, b, _rng.nextInt(201) + 300));
-    return tracks;
-  }
+Future<bool> solveSliderCaptchaManually(
+  BuildContext context,
+  SliderCaptchaClientProvider provider,
+) async {
+  if (!context.mounted) return false;
+  return await Navigator.of(context).push<bool>(
+        MaterialPageRoute(
+          builder: (context) => CaptchaWidget(provider: provider),
+        ),
+      ) ==
+      true;
 }
 
 class CaptchaWidget extends StatefulWidget {
@@ -570,8 +268,8 @@ class _CaptchaWidgetState extends State<CaptchaWidget> {
   }
 
   Widget _buildCaptcha(SliderCaptchaClientProvider provider) {
-    final pw = provider._puzzleWidth;
-    final ph = provider._puzzleHeight;
+    final pw = provider.puzzleWidth;
+    final ph = provider.puzzleHeight;
     return Column(
       children: [
         SizedBox(
@@ -580,10 +278,20 @@ class _CaptchaWidgetState extends State<CaptchaWidget> {
           child: Stack(
             alignment: Alignment.center,
             children: [
-              provider._puzzleImage!.value,
+              Image.memory(
+                provider.puzzleData!,
+                width: provider.puzzleWidth,
+                height: provider.puzzleHeight,
+                fit: BoxFit.fitWidth,
+              ),
               Positioned(
                 left: _sliderLeftPx,
-                child: provider._pieceImage!.value,
+                child: Image.memory(
+                  provider.pieceData!,
+                  width: provider.pieceWidth,
+                  height: provider.pieceHeight,
+                  fit: BoxFit.fitWidth,
+                ),
               ),
             ],
           ),
@@ -633,5 +341,3 @@ class _CaptchaWidgetState extends State<CaptchaWidget> {
     );
   }
 }
-
-class CaptchaSolveFailedException implements Exception {}

--- a/lib/page/login/login_window.dart
+++ b/lib/page/login/login_window.dart
@@ -16,6 +16,7 @@ import 'package:sn_progress_dialog/sn_progress_dialog.dart';
 import 'package:styled_widget/styled_widget.dart';
 import 'package:watermeter/page/public_widget/app_icon.dart';
 import 'package:watermeter/page/login/jc_captcha.dart';
+import 'package:watermeter/repository/xidian_ids/slider_captcha_client.dart';
 import 'package:watermeter/repository/xidian_ids/ehall_session.dart';
 import 'package:watermeter/repository/preference.dart' as preference;
 import 'package:watermeter/page/homepage/home.dart';
@@ -144,7 +145,10 @@ class _LoginWindowState extends State<LoginWindow> {
           value: number,
         ),
         sliderCaptcha: (String cookieStr) {
-          return SliderCaptchaClientProvider(cookie: cookieStr).solve(context);
+          return SliderCaptchaClientProvider(cookie: cookieStr).solve(
+            manualSolver: (provider) =>
+                solveSliderCaptchaManually(context, provider),
+          );
         },
       );
       if (!mounted) return;

--- a/lib/repository/xidian_ids/classtable_session.dart
+++ b/lib/repository/xidian_ids/classtable_session.dart
@@ -13,7 +13,7 @@ import 'package:intl/intl.dart';
 import 'package:time/time.dart';
 import 'package:watermeter/bridge/save_to_groupid.g.dart';
 import 'package:watermeter/model/fetch_result.dart';
-import 'package:watermeter/page/login/jc_captcha.dart';
+import 'package:watermeter/repository/xidian_ids/slider_captcha_client.dart';
 import 'package:watermeter/repository/logger.dart';
 import 'package:watermeter/repository/network_session.dart';
 import 'package:watermeter/repository/preference.dart' as pref;
@@ -124,7 +124,7 @@ class ClassTableSession extends EhallSession {
           "https://yjspt.xidian.edu.cn/gsapp/"
           "sys/wdkbapp/*default/index.do#/xskcb",
       sliderCaptcha: (String cookieStr) =>
-          SliderCaptchaClientProvider(cookie: cookieStr).solve(null),
+          SliderCaptchaClientProvider(cookie: cookieStr).solve(),
     );
 
     while (location != null) {

--- a/lib/repository/xidian_ids/creative_service_session.dart
+++ b/lib/repository/xidian_ids/creative_service_session.dart
@@ -7,7 +7,7 @@
 /*
 import 'dart:io';
 import 'package:dio/dio.dart';
-import 'package:watermeter/page/login/jc_captcha.dart';
+import 'package:watermeter/repository/xidian_ids/slider_captcha_client.dart';
 import 'package:watermeter/repository/logger.dart';
 import 'package:watermeter/model/xidian_ids/creative.dart';
 import 'package:watermeter/repository/xidian_ids/ids_session.dart';
@@ -21,7 +21,7 @@ class CreativeServiceSession extends IDSSession {
       String location = await checkAndLogin(
         target: "$url/login/ids",
         sliderCaptcha: (String cookieStr) =>
-            SliderCaptchaClientProvider(cookie: cookieStr).solve(null),
+            SliderCaptchaClientProvider(cookie: cookieStr).solve(),
       );
       var response = await dio.get(location);
       while (response.headers[HttpHeaders.locationHeader] != null) {

--- a/lib/repository/xidian_ids/ehall_session.dart
+++ b/lib/repository/xidian_ids/ehall_session.dart
@@ -9,7 +9,7 @@ import 'dart:io';
 
 import 'package:dio/dio.dart';
 import 'package:synchronized/synchronized.dart';
-import 'package:watermeter/page/login/jc_captcha.dart';
+import 'package:watermeter/repository/xidian_ids/slider_captcha_client.dart';
 import 'package:watermeter/repository/logger.dart';
 import 'package:watermeter/repository/xidian_ids/ids_session.dart';
 
@@ -81,7 +81,7 @@ class EhallSession extends IDSSession {
               "https://ehall.xidian.edu.cn/login?"
               "service=https://ehall.xidian.edu.cn/new/index.html",
           sliderCaptcha: (String cookieStr) =>
-              SliderCaptchaClientProvider(cookie: cookieStr).solve(null),
+              SliderCaptchaClientProvider(cookie: cookieStr).solve(),
         );
         var response = await dio.get(location);
         while (response.headers[HttpHeaders.locationHeader] != null) {

--- a/lib/repository/xidian_ids/energy_session.dart
+++ b/lib/repository/xidian_ids/energy_session.dart
@@ -13,7 +13,7 @@ import 'package:time/time.dart';
 import 'package:watermeter/model/fetch_result.dart';
 import 'package:watermeter/model/not_school_network_exception.dart';
 import 'package:watermeter/model/xidian_ids/energy.dart';
-import 'package:watermeter/page/login/jc_captcha.dart';
+import 'package:watermeter/repository/xidian_ids/slider_captcha_client.dart';
 import 'package:watermeter/repository/logger.dart';
 import 'package:watermeter/repository/network_session.dart';
 import 'package:watermeter/repository/preference.dart' as preference;
@@ -251,7 +251,7 @@ class EnergySession extends IDSSession {
           "redirect=https://ignypt.xidian.edu.cn/revenueH5/login?"
           "opcode=MPAY&appid=200260318155520600&state=12312312312312&qrcode=0",
       sliderCaptcha: (String cookieStr) =>
-          SliderCaptchaClientProvider(cookie: cookieStr).solve(null),
+          SliderCaptchaClientProvider(cookie: cookieStr).solve(),
     );
 
     var response = await dio.get(location);

--- a/lib/repository/xidian_ids/exam_session.dart
+++ b/lib/repository/xidian_ids/exam_session.dart
@@ -12,7 +12,7 @@ import 'package:dio/dio.dart';
 import 'package:watermeter/bridge/save_to_groupid.g.dart';
 import 'package:watermeter/model/fetch_result.dart';
 import 'package:watermeter/model/xidian_ids/exam.dart';
-import 'package:watermeter/page/login/jc_captcha.dart';
+import 'package:watermeter/repository/xidian_ids/slider_captcha_client.dart';
 import 'package:watermeter/repository/logger.dart';
 import 'package:watermeter/repository/network_session.dart';
 import 'package:watermeter/repository/preference.dart' as pref;
@@ -106,7 +106,7 @@ class ExamSession extends EhallSession {
     String? location = await checkAndLogin(
       target: "https://yjspt.xidian.edu.cn/gsapp/sys/wdksapp/*default/index.do",
       sliderCaptcha: (String cookieStr) =>
-          SliderCaptchaClientProvider(cookie: cookieStr).solve(null),
+          SliderCaptchaClientProvider(cookie: cookieStr).solve(),
     );
 
     while (location != null) {

--- a/lib/repository/xidian_ids/ids_session.dart
+++ b/lib/repository/xidian_ids/ids_session.dart
@@ -11,7 +11,7 @@ import 'package:dio/dio.dart';
 import 'package:html/parser.dart';
 import 'package:encrypter_plus/encrypter_plus.dart' as encrypt;
 import 'package:synchronized/synchronized.dart';
-import 'package:watermeter/page/login/jc_captcha.dart';
+import 'package:watermeter/repository/xidian_ids/slider_captcha_client.dart';
 import 'package:watermeter/repository/logger.dart';
 import 'package:watermeter/repository/network_session.dart';
 import 'package:watermeter/repository/preference.dart' as preference;
@@ -332,7 +332,7 @@ class IDSSession extends NetworkSession {
           "https://yjspt.xidian.edu.cn/gsapp"
           "/sys/yjsemaphome/portal/index.do",
       sliderCaptcha: (cookieStr) =>
-          SliderCaptchaClientProvider(cookie: cookieStr).solve(null),
+          SliderCaptchaClientProvider(cookie: cookieStr).solve(),
     );
     var response = await dio.get(location);
     while (response.headers[HttpHeaders.locationHeader] != null) {

--- a/lib/repository/xidian_ids/jiaowu_service_session.dart
+++ b/lib/repository/xidian_ids/jiaowu_service_session.dart
@@ -7,7 +7,7 @@
 /*
 import 'dart:io';
 import 'package:dio/dio.dart';
-import 'package:watermeter/page/login/jc_captcha.dart';
+import 'package:watermeter/repository/xidian_ids/slider_captcha_client.dart';
 import 'package:watermeter/repository/logger.dart';
 import 'package:watermeter/model/xidian_ids/empty_classroom.dart';
 
@@ -34,7 +34,7 @@ class JiaowuServiceSession extends IDSSession {
           "ehall.xidian.edu.cn%252Fjwmobile%252Fauth%252Findex%26state%3DSTATE"
           "%26qrcode%3D1&from=wap",
       sliderCaptcha: (String cookieStr) =>
-          SliderCaptchaClientProvider(cookie: cookieStr).solve(null),
+          SliderCaptchaClientProvider(cookie: cookieStr).solve(),
     );
 
     var response = await dio.get(location);

--- a/lib/repository/xidian_ids/learning_session.dart
+++ b/lib/repository/xidian_ids/learning_session.dart
@@ -11,7 +11,7 @@ import 'package:html/dom.dart';
 import 'package:html/parser.dart';
 import 'package:watermeter/model/xidian_ids/class_attendance.dart';
 import 'package:watermeter/repository/logger.dart';
-import 'package:watermeter/page/login/jc_captcha.dart';
+import 'package:watermeter/repository/xidian_ids/slider_captcha_client.dart';
 import 'package:watermeter/repository/xidian_ids/ids_session.dart';
 
 class LearningSession extends IDSSession {
@@ -45,7 +45,7 @@ class LearningSession extends IDSSession {
     String? location = await checkAndLogin(
       target: LOGIN_URL,
       sliderCaptcha: (String cookieStr) =>
-          SliderCaptchaClientProvider(cookie: cookieStr).solve(null),
+          SliderCaptchaClientProvider(cookie: cookieStr).solve(),
     );
 
     while (location != null) {

--- a/lib/repository/xidian_ids/library_session.dart
+++ b/lib/repository/xidian_ids/library_session.dart
@@ -8,7 +8,7 @@ import 'dart:convert';
 import 'dart:io';
 import 'package:dio/dio.dart';
 import 'package:pool/pool.dart';
-import 'package:watermeter/page/login/jc_captcha.dart';
+import 'package:watermeter/repository/xidian_ids/slider_captcha_client.dart';
 import 'package:watermeter/repository/logger.dart';
 import 'package:watermeter/model/xidian_ids/library.dart';
 import 'package:watermeter/repository/xidian_ids/ids_session.dart';
@@ -187,7 +187,7 @@ class LibrarySession extends IDSSession {
             "https://hyytsgxzs.xidian.edu.cn/api/index/casLoginDo.html?"
             "libraryId=5&openId=o2b1a5Fg6r8hKcL0FXopEkfmiQGc&source=xdbb",
         sliderCaptcha: (String cookieStr) =>
-            SliderCaptchaClientProvider(cookie: cookieStr).solve(null),
+            SliderCaptchaClientProvider(cookie: cookieStr).solve(),
       );
 
       RegExp matchJson = RegExp(r'wx.miniProgram.postMessage(.*);');
@@ -301,7 +301,7 @@ class LibrarySession extends IDSSession {
   //    String location = await checkAndLogin(
   //      target: "https://tyrzfw.chaoxing.com/auth/xidian/cas/index",
   //      sliderCaptcha: (String cookieStr) =>
-  //          SliderCaptchaClientProvider(cookie: cookieStr).solve(null),
+  //          SliderCaptchaClientProvider(cookie: cookieStr).solve(),
   //    );
   //    var response = await dio.get(location);
   //

--- a/lib/repository/xidian_ids/personal_info_session.dart
+++ b/lib/repository/xidian_ids/personal_info_session.dart
@@ -5,7 +5,7 @@
 import 'dart:io';
 
 import 'package:dio/dio.dart';
-import 'package:watermeter/page/login/jc_captcha.dart';
+import 'package:watermeter/repository/xidian_ids/slider_captcha_client.dart';
 import 'package:watermeter/repository/logger.dart';
 import 'package:watermeter/repository/preference.dart' as preference;
 import 'package:watermeter/repository/xidian_ids/ehall_session.dart';
@@ -15,7 +15,7 @@ class PersonalInfoSession extends EhallSession {
     String location = await checkAndLogin(
       target: "https://yjspt.xidian.edu.cn/",
       sliderCaptcha: (String cookieStr) =>
-          SliderCaptchaClientProvider(cookie: cookieStr).solve(null),
+          SliderCaptchaClientProvider(cookie: cookieStr).solve(),
     );
 
     log.info(
@@ -57,7 +57,7 @@ class PersonalInfoSession extends EhallSession {
       target:
           "https://xgxt.xidian.edu.cn/xsfw/sys/jbxxapp/*default/index.do#/wdxx",
       sliderCaptcha: (String cookieStr) =>
-          SliderCaptchaClientProvider(cookie: cookieStr).solve(null),
+          SliderCaptchaClientProvider(cookie: cookieStr).solve(),
     );
     log.info(
       "[ehall_session][getDormInfoEhall] "

--- a/lib/repository/xidian_ids/score_session.dart
+++ b/lib/repository/xidian_ids/score_session.dart
@@ -12,7 +12,7 @@ import 'dart:io';
 
 import 'package:dio/dio.dart';
 import 'package:watermeter/model/fetch_result.dart';
-import 'package:watermeter/page/login/jc_captcha.dart';
+import 'package:watermeter/repository/xidian_ids/slider_captcha_client.dart';
 import 'package:watermeter/repository/preference.dart' as pref;
 import 'package:watermeter/model/xidian_ids/score.dart';
 import 'package:watermeter/repository/logger.dart';
@@ -126,7 +126,7 @@ class ScoreSession extends EhallSession {
     String? location = await checkAndLogin(
       target: "https://yjspt.xidian.edu.cn/gsapp/sys/wdcjapp/*default/index.do",
       sliderCaptcha: (String cookieStr) =>
-          SliderCaptchaClientProvider(cookie: cookieStr).solve(null),
+          SliderCaptchaClientProvider(cookie: cookieStr).solve(),
     );
 
     while (location != null) {

--- a/lib/repository/xidian_ids/slider_captcha_client.dart
+++ b/lib/repository/xidian_ids/slider_captcha_client.dart
@@ -1,0 +1,302 @@
+// Copyright 2023-2025 BenderBlog Rodriguez and contributors
+// Copyright 2025 Traintime PDA authors.
+// SPDX-License-Identifier: MIT
+
+// https://juejin.cn/post/7284608063914622995
+
+import 'dart:convert';
+import 'dart:io';
+import 'dart:math';
+import 'dart:typed_data';
+import 'package:dio/dio.dart';
+import 'package:image/image.dart' as img;
+import 'package:watermeter/repository/logger.dart';
+import 'package:watermeter/repository/network_session.dart';
+
+/// Finger movement track point
+class TrackPoint {
+  final int a; // x pos
+  final int b; // y pos
+  final int c; // milliseconds
+
+  TrackPoint(this.a, this.b, this.c);
+
+  Map<String, dynamic> toJson() => {'a': a, 'b': b, 'c': c};
+}
+
+class SliderCaptchaClientProvider {
+  final String cookie;
+  Dio dio = Dio()..interceptors.add(logDioAdapter);
+
+  SliderCaptchaClientProvider({required this.cookie});
+
+  static const double _puzzleWidth = 280;
+  static const double _puzzleHeight = 155;
+  static const double _pieceWidth = 44;
+  static const double _pieceHeight = 155;
+  Uint8List? _puzzleData;
+  Uint8List? _pieceData;
+  Uint8List? _aesKey;
+
+  double get puzzleWidth => _puzzleWidth;
+  double get puzzleHeight => _puzzleHeight;
+  double get pieceWidth => _pieceWidth;
+  double get pieceHeight => _pieceHeight;
+  Uint8List? get puzzleData => _puzzleData;
+  Uint8List? get pieceData => _pieceData;
+
+  // fetch and update captcha data
+  Future<void> updatePuzzle() async {
+    // fetch captcha data
+    log.info("Fetching slider captcha...");
+    var rsp = await dio.get(
+      "https://ids.xidian.edu.cn/authserver/common/openSliderCaptcha.htl",
+      queryParameters: {'_': DateTime.now().millisecondsSinceEpoch.toString()},
+      options: Options(headers: {"Cookie": cookie}),
+    );
+    log.info("Captcha fetched, decoding images.");
+    // decode base64 and extract aes key
+    String puzzleBase64 = rsp.data["bigImage"];
+    String pieceBase64 = rsp.data["smallImage"];
+    _puzzleData = const Base64Decoder().convert(puzzleBase64);
+    _pieceData = const Base64Decoder().convert(pieceBase64);
+    _aesKey = _pieceData!.sublist(_pieceData!.length - 16); // key = last 16B
+  }
+
+  // submit and verify captcha
+  Future<bool> verify(List<TrackPoint> tracks) async {
+    final payload = jsonEncode({
+      "canvasLength": _puzzleWidth.toInt(),
+      "moveLength": tracks.isNotEmpty ? tracks.last.a : 0,
+      "tracks": tracks,
+    });
+    final sign = aesEncrypt(payload, _aesKey!);
+    dynamic result = await dio.post(
+      "https://ids.xidian.edu.cn/authserver/common/verifySliderCaptcha.htl",
+      data: "sign=${Uri.encodeQueryComponent(sign)}",
+      options: Options(
+        headers: {
+          HttpHeaders.acceptHeader:
+              "application/json, text/javascript, */*; q=0.01",
+          "Cookie": cookie,
+          HttpHeaders.contentTypeHeader:
+              "application/x-www-form-urlencoded;charset=UTF-8",
+          "Origin": "https://ids.xidian.edu.cn",
+          HttpHeaders.accessControlAllowOriginHeader:
+              "https://ids.xidian.edu.cn",
+          "X-Requested-With": "XMLHttpRequest",
+        },
+      ),
+    );
+    log.info("Tried captcha payload:$payload, result:${result.data}");
+    return result.data["errorCode"] == 1;
+  }
+
+  // solve slider captcha
+  Future<void> solve({
+    Future<bool> Function(SliderCaptchaClientProvider provider)? manualSolver,
+  }) async {
+    log.info("Solving slider captcha automatically");
+    // multiple tries
+    for (int i = 0; i < 6; ++i) {
+      // refresh captcha
+      await updatePuzzle();
+      final offset = solveOffset(_puzzleData!, _pieceData!);
+      if (offset == null) throw CaptchaSolveFailedException();
+      final int baseMove = (offset * _puzzleWidth).round();
+      // try neighboring moves
+      for (final delta in [1, -1, 2, -2, 3, -3, 4]) {
+        final move = baseMove + delta;
+        if (move < 0 || move > _puzzleWidth.toInt()) continue;
+        final tracks = generateTracks(move);
+        // sleep
+        await Future.delayed(
+          Duration(milliseconds: max(tracks.last.c - 100, 0)),
+        );
+        // verify
+        try {
+          if (await verify(tracks)) return;
+        } catch (_) {}
+      }
+    }
+    // fallback to manual solving
+    log.info("Solving slider captcha manually");
+    if (manualSolver != null && await manualSolver(this)) return;
+    throw CaptchaSolveFailedException();
+  }
+
+  ///
+  /// Slider CAPTCHA offset solver
+  ///
+
+  // match offset with ncc.
+  static double? solveOffset(
+    Uint8List puzzleData,
+    Uint8List pieceData, {
+    int border = 24,
+  }) {
+    img.Image? puzzle = img.decodeImage(puzzleData);
+    if (puzzle == null) return null;
+    img.Image? piece = img.decodeImage(pieceData);
+    if (piece == null) return null;
+    final bbox = _imageBbox(piece);
+    var xL = bbox.$1 + border;
+    var yT = bbox.$2 + border;
+    var xR = bbox.$3 - border;
+    var yB = bbox.$4 - border;
+
+    final windowWidth = xR - xL + 1;
+    final windowHeight = yB - yT + 1;
+    final bigWidth = puzzle.width - piece.width + windowWidth;
+    final templateMean =
+        _imageSum(piece, xL, yT, windowWidth, windowHeight) /
+        (windowWidth * windowHeight);
+    final template = _imageNorm(
+      piece,
+      xL,
+      yT,
+      windowWidth,
+      windowHeight,
+      templateMean,
+    );
+    final columnSums = List<double>.generate(
+      bigWidth,
+      (x) => _imageSum(puzzle, x + xL, yT, 1, windowHeight),
+      growable: false,
+    );
+
+    var windowSum = 0.0;
+    for (var x = 0; x < windowWidth; x++) {
+      windowSum += columnSums[x];
+    }
+    final area = windowWidth * windowHeight;
+    var nccMax = _imageNcc(
+      puzzle,
+      0 + xL,
+      yT,
+      windowWidth,
+      windowHeight,
+      template,
+      windowSum / area,
+    );
+    var xMax = 0;
+    for (var x = 1; x < bigWidth - windowWidth; x++) {
+      windowSum += columnSums[x + windowWidth - 1] - columnSums[x - 1];
+      final ncc = _imageNcc(
+        puzzle,
+        x + xL,
+        yT,
+        windowWidth,
+        windowHeight,
+        template,
+        windowSum / area,
+      );
+      if (ncc > nccMax) {
+        nccMax = ncc;
+        xMax = x;
+      }
+    }
+    return xMax / puzzle.width;
+  }
+
+  // find bbox
+  static (int, int, int, int) _imageBbox(img.Image image) {
+    var xL = image.width, yT = image.height, xR = 0, yB = 0;
+    for (var y = 0; y < image.height; y++) {
+      for (var x = 0; x < image.width; x++) {
+        if (image.getPixel(x, y).a.toInt() == 255) {
+          if (x < xL) xL = x;
+          if (y < yT) yT = y;
+          if (x > xR) xR = x;
+          if (y > yB) yB = y;
+        }
+      }
+    }
+    return (xL, yT, xR, yB);
+  }
+
+  // calculate sum of area in an image
+  static double _imageSum(
+    img.Image image,
+    int xL,
+    int yT,
+    int width,
+    int height,
+  ) {
+    double sum = 0;
+    for (var y = yT; y < yT + height; y++) {
+      for (var x = xL; x < xL + width; x++) {
+        sum += image.getPixel(x, y).luminance;
+      }
+    }
+    return sum;
+  }
+
+  // normalize area in an image
+  static List<double> _imageNorm(
+    img.Image image,
+    int xL,
+    int yT,
+    int width,
+    int height,
+    double mean,
+  ) {
+    return [
+      for (var y = yT; y < yT + height; y++)
+        for (var x = xL; x < xL + width; x++)
+          image.getPixel(x, y).luminance - mean,
+    ];
+  }
+
+  // calculate ncc of area in an image with a template
+  static double _imageNcc(
+    img.Image window,
+    int xL,
+    int yT,
+    int width,
+    int height,
+    List<double> template,
+    double meanW,
+  ) {
+    double sumWt = 0, sumWw = 0.000001;
+    var iT = template.iterator;
+    for (var y = yT; y < yT + height; y++) {
+      for (var x = xL; x < xL + width; x++) {
+        iT.moveNext();
+        var w = window.getPixel(x, y).luminance - meanW;
+        sumWt += w * iT.current;
+        sumWw += w * w;
+      }
+    }
+    return sumWt / sumWw;
+  }
+
+  ///
+  /// Finger move track generation
+  ///
+
+  static final _rng = Random();
+  static final _genTracksNorm = 1.0 / (1.0 + exp(-7.0 * (1.0 - 0.42)));
+
+  // generate track along an skewed sigmoid curve
+  static List<TrackPoint> generateTracks(int offs) {
+    final tracks = <TrackPoint>[TrackPoint(0, 0, 0)];
+    final int n = _rng.nextInt(5) + 10;
+    int b = 0;
+    for (int i = 0; i < n; i++) {
+      // horizontal
+      final double z =
+          (1.0 / (1.0 + exp(-7.0 * ((i / n) - 0.42)))) / _genTracksNorm;
+      final int a = min(offs - 1, max(tracks.last.a + 1, (offs * z).round()));
+      // vertical
+      final double r = _rng.nextDouble();
+      b = ((r < 0.65) ? (b - 1) : ((r < 0.80) ? (b + 1) : (b)));
+      b = max(-10, min(10, b));
+      tracks.add(TrackPoint(a, b, _rng.nextInt(201) + 300));
+    }
+    tracks.add(TrackPoint(offs, b, _rng.nextInt(201) + 300));
+    return tracks;
+  }
+}
+
+class CaptchaSolveFailedException implements Exception {}

--- a/lib/repository/xidian_ids/sysj_session.dart
+++ b/lib/repository/xidian_ids/sysj_session.dart
@@ -13,7 +13,7 @@ import 'package:watermeter/model/fetch_result.dart';
 import 'package:watermeter/model/not_school_network_exception.dart';
 import 'package:watermeter/model/xidian_ids/experiment.dart';
 import 'package:watermeter/model/time_list.dart';
-import 'package:watermeter/page/login/jc_captcha.dart';
+import 'package:watermeter/repository/xidian_ids/slider_captcha_client.dart';
 import 'package:watermeter/repository/logger.dart';
 import 'package:watermeter/repository/network_session.dart';
 import 'package:watermeter/repository/preference.dart' as prefs;
@@ -197,7 +197,7 @@ class SysjSession extends IDSSession {
         location = await checkAndLogin(
           target: hrefIds.queryParameters["service"]!,
           sliderCaptcha: (String cookieStr) =>
-              SliderCaptchaClientProvider(cookie: cookieStr).solve(null),
+              SliderCaptchaClientProvider(cookie: cookieStr).solve(),
         );
       } else {
         location = hrefIds.toString();


### PR DESCRIPTION
拆分自PR #150. 

## Summary

这个 PR 做两件比较小但相互独立风险都不高的事：

1. 把滑块验证码的非 UI 逻辑从登录页 widget 里拆出来；
2. 修复首页“明日安排”在周日可能算错周数的问题。

## What Changed

- 新增 `lib/repository/xidian_ids/slider_captcha_client.dart`
  - 放置 `SliderCaptchaClientProvider`
  - 放置 `CaptchaSolveFailedException`
  - 放置自动滑块识别、轨迹生成、验证码提交校验等非 UI 逻辑

- `lib/page/login/jc_captcha.dart` 现在只保留手动验证码 UI：
  - 自动求解失败后，通过 `manualSolver` callback 进入 UI 流程
  - repository 不再需要 import 登录页面

- 更新 `lib/repository/xidian_ids/*_session.dart`
  - 从 import `page/login/jc_captcha.dart`
  - 改成 import `repository/xidian_ids/slider_captcha_client.dart`

- 修复首页“明日安排”的日期计算：
  - `ClassTableController.getArrangementOfDay(updateTime)` 现在用传入日期计算当前周
  - 首页卡片展示明日安排时，也使用明日日期生成周数与日期文案
  - 避免周日查看“明日安排”时仍使用本周周数，导致拐到上一周/本周错误日期

## Why

原来 repository 层依赖登录页 UI 文件，方向不太对，也让验证码逻辑难以复用，想要复用则会产生大量逆向依赖。拆出非 UI client 后，repository 只依赖 repository 内部代码，登录页 UI 反过来复用这个 client。

周日“明日安排”问题是一个实际日期边界 bug：明日安排应该以“明天”的日期计算周数，而不是当前时间所在周。