### PR TITLE
feat: add captcha refresh in schoolnet dialog

### DIFF
--- a/assets/flutter_i18n/en_US.yaml
+++ b/assets/flutter_i18n/en_US.yaml
@@ -665,6 +665,7 @@ login:
     title: Please enter captcha
     hint: Input captcha
     message_on_empty: Please enter captcha
+    refresh_failed: "Failed to refresh captcha: {error}"
   slider_title: Server authentication service
 school_net:
   title: School Net Usage Query

--- a/assets/flutter_i18n/zh_CN.yaml
+++ b/assets/flutter_i18n/zh_CN.yaml
@@ -593,6 +593,7 @@ login:
     title: 请输入验证码
     hint: 输入验证码
     message_on_empty: 请输入验证码
+    refresh_failed: "刷新验证码失败: {error}"
   slider_title: 服务器认证服务
 school_net:
   title: 校园网使用详情

--- a/assets/flutter_i18n/zh_TW.yaml
+++ b/assets/flutter_i18n/zh_TW.yaml
@@ -591,6 +591,7 @@ login:
     title: 請輸入驗證碼
     hint: 輸入驗證碼
     message_on_empty: 請輸入驗證碼
+    refresh_failed: "刷新驗證碼失敗: {error}"
   slider_title: 服務器認證服務
 school_net:
   title: 校園網使用詳情

--- a/lib/page/public_widget/captcha_input_dialog.dart
+++ b/lib/page/public_widget/captcha_input_dialog.dart
@@ -12,11 +12,62 @@ import 'package:flutter/material.dart';
 import 'package:flutter_i18n/flutter_i18n.dart';
 import 'package:watermeter/page/public_widget/toast.dart';
 
-class CaptchaInputDialog extends StatelessWidget {
-  final TextEditingController _captchaController = TextEditingController();
+class CaptchaInputDialog extends StatefulWidget {
   final List<int> image;
+  final Future<List<int>> Function()? onRefresh;
 
-  CaptchaInputDialog({super.key, required this.image});
+  const CaptchaInputDialog({super.key, required this.image, this.onRefresh});
+
+  @override
+  State<CaptchaInputDialog> createState() => _CaptchaInputDialogState();
+}
+
+class _CaptchaInputDialogState extends State<CaptchaInputDialog> {
+  final TextEditingController _captchaController = TextEditingController();
+  late Uint8List _currentImageBytes;
+  bool _isLoading = false;
+
+  @override
+  void initState() {
+    super.initState();
+    _currentImageBytes = Uint8List.fromList(widget.image);
+  }
+
+  @override
+  void dispose() {
+    _captchaController.dispose();
+    super.dispose();
+  }
+
+  Future<void> _handleRefresh() async {
+    if (widget.onRefresh == null || _isLoading) return;
+    setState(() {
+      _isLoading = true;
+    });
+    try {
+      final newImage = await widget.onRefresh!();
+      setState(() {
+        _currentImageBytes = Uint8List.fromList(newImage);
+      });
+    } catch (e) {
+      if (mounted) {
+        showToast(
+          context: context,
+          msg: FlutterI18n.translate(
+            context,
+            "login.captcha_window.refresh_failed",
+            translationParams: {"error": e.toString()},
+          ),
+        );
+      }
+    } finally {
+      if (mounted) {
+        setState(() {
+          _isLoading = false;
+        });
+      }
+    }
+  }
 
   @override
   Widget build(BuildContext context) {
@@ -27,7 +78,17 @@ class CaptchaInputDialog extends StatelessWidget {
         mainAxisSize: MainAxisSize.min,
         mainAxisAlignment: MainAxisAlignment.center,
         children: [
-          Image.memory(Uint8List.fromList(image)),
+          GestureDetector(
+            onTap: _handleRefresh,
+            child: Stack(
+              alignment: Alignment.center,
+              children: [
+                Image.memory(_currentImageBytes),
+                if (_isLoading)
+                  const CircularProgressIndicator(),
+              ],
+            ),
+          ),
           const SizedBox(height: 16),
           TextField(
             autofocus: true,

--- a/lib/page/schoolnet/general_network_usage_page.dart
+++ b/lib/page/schoolnet/general_network_usage_page.dart
@@ -36,9 +36,12 @@ class _GeneralNetworkUsagePageState extends State<GeneralNetworkUsagePage>
 
   Future<void> _reload(BuildContext context) =>
       state = session.getGeneralNetworkUsage(
-        captchaFunction: (image) => showDialog<String>(
+        captchaFunction: (image, onRefresh) => showDialog<String>(
           context: context,
-          builder: (context) => CaptchaInputDialog(image: image),
+          builder: (context) => CaptchaInputDialog(
+            image: image,
+            onRefresh: onRefresh,
+          ),
         ).then((value) => value ?? ""),
       );
 

--- a/lib/repository/schoolnet_session.dart
+++ b/lib/repository/schoolnet_session.dart
@@ -126,7 +126,10 @@ class SchoolnetSession extends NetworkSession {
   }
 
   Future<FetchResult<GeneralNetworkUsage>> getGeneralNetworkUsage({
-    required Future<String> Function(List<int>) captchaFunction,
+    required Future<String> Function(
+      List<int> initialImage,
+      Future<List<int>> Function() onRefresh,
+    ) captchaFunction,
   }) async {
     try {
       // Get username and password
@@ -182,26 +185,30 @@ class SchoolnetSession extends NetworkSession {
 
       String lastErrorMessage = "";
 
-      // Refresh captcha
-      log.info("[SchoolnetSession][getGeneralNetworkUsage] Refresh captcha");
-      await _dio.get(
-        'https://zfw.xidian.edu.cn/site/captcha',
-        queryParameters: {
-          'refresh': 1,
-          '_': DateTime.now().millisecondsSinceEpoch,
-        },
-      );
+      // Refresh and fetch captcha helper
+      Future<List<int>> refreshCaptcha() async {
+        log.info("[SchoolnetSession][getGeneralNetworkUsage] Refreshing captcha via API");
+        await _dio.get(
+          'https://zfw.xidian.edu.cn/site/captcha',
+          queryParameters: {
+            'refresh': 1,
+            '_': DateTime.now().millisecondsSinceEpoch,
+          },
+        );
+        var picture = await _dio.get(
+          "https://zfw.xidian.edu.cn/site/captcha",
+          options: Options(responseType: ResponseType.bytes),
+        ).then((data) => data.data);
 
-      // Get verifycode
-      log.info("[SchoolnetSession][getGeneralNetworkUsage] Get verifycode");
-      var picture = await _dio
-          .get(
-            "https://zfw.xidian.edu.cn/site/captcha",
-            options: Options(responseType: ResponseType.bytes),
-          )
-          .then((data) => data.data);
+        if (picture is List<int>) {
+          return picture;
+        }
+        throw Exception("Failed to load captcha image bytes");
+      }
+
+      var picture = await refreshCaptcha();
       String failedmsg = "school_net.captcha_failed";
-      String? verifycode = await captchaFunction(picture);
+      String? verifycode = await captchaFunction(picture, refreshCaptcha);
 
       // If failed too much time, set error state.
       if (verifycode == failedmsg || verifycode == "") {


### PR DESCRIPTION
校园网查询页面的验证码图片有时候看不清（深色主题下这点比较明显），想点一下图片刷新，等了半天也没看到新图片，~~我当时还以为是我网卡了呢~~

功能说明：用户现点击验证码图片后，可直接获取新的图片验证码，实现“看不清？换一张”的效果。

代码改动说明：
  - 将 CaptchaInputDialog 改为 StatefulWidget，支持动态更新图片
  - 点击验证码图片触发刷新，展示 loading 遮罩状态
  - 在 schoolnet_session 中提取 refreshCaptcha 闭包
  - 将 onRefresh 回调通过 captchaFunction 传入对话框
  - i18n 文件各新增一键值对，为刷新失败时的提示消息
