### PR TITLE
加入低电量卡片变色提醒

### DIFF
--- a/assets/flutter_i18n/en_US.yaml
+++ b/assets/flutter_i18n/en_US.yaml
@@ -803,6 +803,15 @@ setting:
   color_setting: Color theme
   simplify_timeline: Simplify schedule timeline
   simplify_timeline_description: Reduce space occupation while no schedule
+  low_electricity_warning: Low electricity card color warning
+  low_electricity_warning_description:
+    Change the homepage electricity card color when remaining electricity is below
+    the threshold
+  low_electricity_threshold: Low electricity threshold
+  low_electricity_threshold_description: "Current: {threshold} kWh"
+  low_electricity_threshold_dialog:
+    title: Set low electricity threshold
+    input_hint: Input remaining electricity
   account_setting: Account Settings
   sport_password_setting: PE system password
   experiment_password_setting: Physics experiment password

--- a/assets/flutter_i18n/zh_CN.yaml
+++ b/assets/flutter_i18n/zh_CN.yaml
@@ -726,6 +726,13 @@ setting:
   color_setting: 颜色设置
   simplify_timeline: 简化日程时间轴
   simplify_timeline_description: 没有日程时 减少空间占用
+  low_electricity_warning: 低电量卡片变色提醒
+  low_electricity_warning_description: 电量小于阈值时 电量卡片变色提醒
+  low_electricity_threshold: 低电量阈值
+  low_electricity_threshold_description: 当前为 {threshold} 度
+  low_electricity_threshold_dialog:
+    title: 设置低电量阈值
+    input_hint: 请输入电量度数
   account_setting: 账号设置
   sport_password_setting: 体育系统密码设置
   experiment_password_setting: 物理实验系统密码设置

--- a/assets/flutter_i18n/zh_TW.yaml
+++ b/assets/flutter_i18n/zh_TW.yaml
@@ -724,6 +724,13 @@ setting:
   color_setting: 顏色設置
   simplify_timeline: 簡化日程時間軸
   simplify_timeline_description: 沒有日程時 減少空間佔用
+  low_electricity_warning: 低電量卡片變色提醒
+  low_electricity_warning_description: 電量小於閾值時 電量卡片變色提醒
+  low_electricity_threshold: 低電量閾值
+  low_electricity_threshold_description: 目前為 {threshold} 度
+  low_electricity_threshold_dialog:
+    title: 設置低電量閾值
+    input_hint: 請輸入電量度數
   account_setting: 賬號設置
   sport_password_setting: 體育系統密碼設置
   experiment_password_setting: 物理實驗系統密碼設置

--- a/lib/controller/energy_controller.dart
+++ b/lib/controller/energy_controller.dart
@@ -6,13 +6,17 @@ import 'package:time/time.dart';
 import 'package:watermeter/model/fetch_result.dart';
 import 'package:watermeter/model/xidian_ids/energy.dart';
 import 'package:watermeter/repository/logger.dart';
+import 'package:watermeter/repository/preference.dart' as preference;
 import 'package:watermeter/repository/xidian_ids/energy_session.dart';
 
 class EnergyController {
   static final EnergyController i = EnergyController._();
+  static const int defaultLowElectricityWarningThreshold = 20;
   bool _isReloading = false;
 
   EnergyController._() {
+    updateElectricityWarning();
+
     // Load last successful fetched electricity info
     final cache = EnergySession.getCache();
     if (cache != null) {
@@ -30,7 +34,48 @@ class EnergyController {
   final energyInfoStateSignal = signal<AsyncState<FetchResult<EnergyInfo>>>(
     const AsyncLoading(),
   );
+  final electricityWarning = signal<int>(defaultLowElectricityWarningThreshold);
   final historyElectricityInfoList = <ElectricityHistoryInfo>[];
+
+  int _readElectricityWarning() {
+    final isEnabled =
+        !preference.contains(
+          preference.Preference.lowElectricityWarningEnabled,
+        ) ||
+        preference.getBool(preference.Preference.lowElectricityWarningEnabled);
+    if (!isEnabled) return -1;
+
+    if (!preference.contains(
+      preference.Preference.lowElectricityWarningThreshold,
+    )) {
+      return defaultLowElectricityWarningThreshold;
+    }
+
+    final threshold = preference.getInt(
+      preference.Preference.lowElectricityWarningThreshold,
+    );
+    return threshold > 0 ? threshold : defaultLowElectricityWarningThreshold;
+  }
+
+  void updateElectricityWarning() {
+    electricityWarning.value = _readElectricityWarning();
+  }
+
+  Future<void> setLowElectricityWarningEnabled(bool value) async {
+    await preference.setBool(
+      preference.Preference.lowElectricityWarningEnabled,
+      value,
+    );
+    updateElectricityWarning();
+  }
+
+  Future<void> setLowElectricityWarningThreshold(int value) async {
+    await preference.setInt(
+      preference.Preference.lowElectricityWarningThreshold,
+      value > 0 ? value : defaultLowElectricityWarningThreshold,
+    );
+    updateElectricityWarning();
+  }
 
   void _syncLastValidElectricity(FetchResult<EnergyInfo> result) {
     _lastValidEnergyInfo.value = result;

--- a/lib/page/homepage/home_card_padding.dart
+++ b/lib/page/homepage/home_card_padding.dart
@@ -5,7 +5,7 @@
 import 'package:flutter/material.dart';
 import 'package:styled_widget/styled_widget.dart';
 
-enum HomeCardType { plain, filled }
+enum HomeCardType { plain, filled, warning }
 
 extension HomeCardPadding on Widget {
   Widget withHomeCardStyle(
@@ -27,6 +27,9 @@ extension HomeCardPadding on Widget {
         iconSize: WidgetStateProperty.all(20),
         backgroundColor: WidgetStateProperty.resolveWith((states) {
           final colorScheme = Theme.of(context).colorScheme;
+          if (type == HomeCardType.warning) {
+            return colorScheme.errorContainer;
+          }
           if (type == HomeCardType.filled) {
             return colorScheme.surfaceContainerHigh;
           }
@@ -34,6 +37,9 @@ extension HomeCardPadding on Widget {
         }),
         foregroundColor: WidgetStateProperty.resolveWith((states) {
           final colorScheme = Theme.of(context).colorScheme;
+          if (type == HomeCardType.warning) {
+            return colorScheme.onErrorContainer;
+          }
           if (type == HomeCardType.filled) {
             return colorScheme.onSurfaceVariant;
           }
@@ -41,6 +47,9 @@ extension HomeCardPadding on Widget {
         }),
         side: WidgetStateProperty.resolveWith((states) {
           final colorScheme = Theme.of(context).colorScheme;
+          if (type == HomeCardType.warning) {
+            return BorderSide(color: colorScheme.error);
+          }
           if (type == HomeCardType.filled) {
             return BorderSide.none;
           }
@@ -56,7 +65,9 @@ extension HomeCardPadding on Widget {
       onPressed: onPressed,
       child: DefaultTextStyle(
         style: TextStyle(
-          color: Theme.of(context).brightness == Brightness.dark
+          color: type == HomeCardType.warning
+              ? Theme.of(context).colorScheme.onErrorContainer
+              : Theme.of(context).brightness == Brightness.dark
               ? Theme.of(context).colorScheme.onSurface
               : Theme.of(context).colorScheme.onSurfaceVariant,
         ),

--- a/lib/page/homepage/info_widget/energy_card.dart
+++ b/lib/page/homepage/info_widget/energy_card.dart
@@ -12,10 +12,7 @@ import 'package:watermeter/controller/energy_controller.dart';
 import 'package:watermeter/page/homepage/home_card_padding.dart';
 import 'package:watermeter/page/homepage/main_page_card.dart';
 import 'package:watermeter/page/public_widget/context_extension.dart';
-import 'package:watermeter/repository/preference.dart' as preference;
 import 'package:watermeter/routing/routes.dart';
-
-const int _defaultLowElectricityWarningThreshold = 20;
 
 class EnergyCard extends StatelessWidget {
   const EnergyCard({super.key});
@@ -27,28 +24,11 @@ class EnergyCard extends StatelessWidget {
       builder: (context) {
         final state = controller.energyInfoStateSignal.value;
         final displayInfo = controller.displayEnergyInfo.value;
-        final lowElectricityWarningEnabled =
-            !preference.contains(
-              preference.Preference.lowElectricityWarningEnabled,
-            ) ||
-            preference.getBool(
-              preference.Preference.lowElectricityWarningEnabled,
-            );
-        final lowElectricityWarningThreshold =
-            preference.contains(
-              preference.Preference.lowElectricityWarningThreshold,
-            )
-            ? preference.getInt(
-                preference.Preference.lowElectricityWarningThreshold,
-              )
-            : _defaultLowElectricityWarningThreshold;
-        final effectiveThreshold = lowElectricityWarningThreshold > 0
-            ? lowElectricityWarningThreshold
-            : _defaultLowElectricityWarningThreshold;
+        final electricityWarning = controller.electricityWarning.value;
         final lowElectricityWarning =
             displayInfo != null &&
-            lowElectricityWarningEnabled &&
-            displayInfo.electricityRemain < effectiveThreshold;
+            electricityWarning >= 0 &&
+            displayInfo.electricityRemain < electricityWarning;
 
         return MainPageCard(
           onPressed: () async {

--- a/lib/page/homepage/info_widget/energy_card.dart
+++ b/lib/page/homepage/info_widget/energy_card.dart
@@ -9,9 +9,13 @@ import 'package:intl/intl.dart';
 import 'package:ming_cute_icons/ming_cute_icons.dart';
 import 'package:signals/signals_flutter.dart';
 import 'package:watermeter/controller/energy_controller.dart';
+import 'package:watermeter/page/homepage/home_card_padding.dart';
 import 'package:watermeter/page/homepage/main_page_card.dart';
 import 'package:watermeter/page/public_widget/context_extension.dart';
+import 'package:watermeter/repository/preference.dart' as preference;
 import 'package:watermeter/routing/routes.dart';
+
+const int _defaultLowElectricityWarningThreshold = 20;
 
 class EnergyCard extends StatelessWidget {
   const EnergyCard({super.key});
@@ -23,6 +27,28 @@ class EnergyCard extends StatelessWidget {
       builder: (context) {
         final state = controller.energyInfoStateSignal.value;
         final displayInfo = controller.displayEnergyInfo.value;
+        final lowElectricityWarningEnabled =
+            !preference.contains(
+              preference.Preference.lowElectricityWarningEnabled,
+            ) ||
+            preference.getBool(
+              preference.Preference.lowElectricityWarningEnabled,
+            );
+        final lowElectricityWarningThreshold =
+            preference.contains(
+              preference.Preference.lowElectricityWarningThreshold,
+            )
+            ? preference.getInt(
+                preference.Preference.lowElectricityWarningThreshold,
+              )
+            : _defaultLowElectricityWarningThreshold;
+        final effectiveThreshold = lowElectricityWarningThreshold > 0
+            ? lowElectricityWarningThreshold
+            : _defaultLowElectricityWarningThreshold;
+        final lowElectricityWarning =
+            displayInfo != null &&
+            lowElectricityWarningEnabled &&
+            displayInfo.electricityRemain < effectiveThreshold;
 
         return MainPageCard(
           onPressed: () async {
@@ -30,6 +56,9 @@ class EnergyCard extends StatelessWidget {
           },
           isLoad: state.isLoading && displayInfo == null,
           icon: MingCuteIcons.mgc_flash_line,
+          type: lowElectricityWarning
+              ? HomeCardType.warning
+              : HomeCardType.plain,
           text: FlutterI18n.translate(
             context,
             "homepage.electricity_card.title",

--- a/lib/page/homepage/main_page_card.dart
+++ b/lib/page/homepage/main_page_card.dart
@@ -14,6 +14,7 @@ class MainPageCard extends StatelessWidget {
   final Widget bottomText;
   final Widget? rightButton;
   final bool? isBold;
+  final HomeCardType type;
   final void Function()? onPressed;
   const MainPageCard({
     super.key,
@@ -26,19 +27,25 @@ class MainPageCard extends StatelessWidget {
     this.rightButton,
     this.progress,
     this.isBold,
+    this.type = HomeCardType.plain,
   });
 
   @override
   Widget build(BuildContext context) {
+    final textColor = type == HomeCardType.warning
+        ? Theme.of(context).colorScheme.onErrorContainer
+        : Theme.of(context).brightness == Brightness.dark
+        ? Theme.of(context).colorScheme.onSurface
+        : Theme.of(context).colorScheme.onSurfaceVariant;
     return ListTile(
       leading: Icon(
         icon,
         size: 32,
-        color: Theme.of(context).colorScheme.primary,
+        color: type == HomeCardType.warning
+            ? Theme.of(context).colorScheme.onErrorContainer
+            : Theme.of(context).colorScheme.primary,
       ),
-      textColor: Theme.of(context).brightness == Brightness.dark
-          ? Theme.of(context).colorScheme.onSurface
-          : Theme.of(context).colorScheme.onSurfaceVariant,
+      textColor: textColor,
       title: infoText,
       subtitle: Builder(
         builder: (context) {
@@ -57,6 +64,6 @@ class MainPageCard extends StatelessWidget {
         },
       ),
       trailing: rightButton,
-    ).withHomeCardStyle(context, onPressed: onPressed);
+    ).withHomeCardStyle(context, onPressed: onPressed, type: type);
   }
 }

--- a/lib/page/setting/setting.dart
+++ b/lib/page/setting/setting.dart
@@ -34,6 +34,7 @@ import 'package:watermeter/page/public_widget/toast.dart';
 import 'package:restart_app/restart_app.dart';
 import 'package:sn_progress_dialog/progress_dialog.dart';
 import 'package:watermeter/controller/classtable_controller.dart';
+import 'package:watermeter/controller/energy_controller.dart';
 import 'package:watermeter/controller/exam_controller.dart';
 import 'package:watermeter/controller/other_experiment_controller.dart';
 import 'package:watermeter/controller/physics_experiment_controller.dart';
@@ -63,8 +64,6 @@ class SettingWindow extends StatefulWidget {
   State<SettingWindow> createState() => _SettingWindowState();
 }
 
-const int _defaultLowElectricityWarningThreshold = 20;
-
 class _SettingWindowState extends State<SettingWindow> {
   Widget _buildListSubtitle(String text) => Text(
     text,
@@ -91,22 +90,12 @@ class _SettingWindowState extends State<SettingWindow> {
   }
 
   bool get _lowElectricityWarningEnabled =>
-      !preference.contains(
-        preference.Preference.lowElectricityWarningEnabled,
-      ) ||
-      preference.getBool(preference.Preference.lowElectricityWarningEnabled);
+      EnergyController.i.electricityWarning.value >= 0;
 
-  int get _lowElectricityWarningThreshold {
-    final value =
-        preference.contains(
-          preference.Preference.lowElectricityWarningThreshold,
-        )
-        ? preference.getInt(
-            preference.Preference.lowElectricityWarningThreshold,
-          )
-        : _defaultLowElectricityWarningThreshold;
-    return value > 0 ? value : _defaultLowElectricityWarningThreshold;
-  }
+  int get _lowElectricityWarningThreshold =>
+      EnergyController.i.electricityWarning.value > 0
+      ? EnergyController.i.electricityWarning.value
+      : EnergyController.defaultLowElectricityWarningThreshold;
 
   Future<void> _showLowElectricityThresholdDialog() async {
     var inputText = _lowElectricityWarningThreshold.toString();
@@ -145,7 +134,7 @@ class _SettingWindowState extends State<SettingWindow> {
               Navigator.pop(
                 context,
                 parsed == null || parsed <= 0
-                    ? _defaultLowElectricityWarningThreshold
+                    ? EnergyController.defaultLowElectricityWarningThreshold
                     : parsed,
               );
             },
@@ -156,10 +145,7 @@ class _SettingWindowState extends State<SettingWindow> {
     );
 
     if (value == null) return;
-    await preference.setInt(
-      preference.Preference.lowElectricityWarningThreshold,
-      value,
-    );
+    await EnergyController.i.setLowElectricityWarningThreshold(value);
     if (mounted) {
       setState(() {});
     }
@@ -437,8 +423,7 @@ class _SettingWindowState extends State<SettingWindow> {
                   trailing: Switch(
                     value: _lowElectricityWarningEnabled,
                     onChanged: (bool value) async {
-                      await preference.setBool(
-                        preference.Preference.lowElectricityWarningEnabled,
+                      await EnergyController.i.setLowElectricityWarningEnabled(
                         value,
                       );
                       if (mounted) {

--- a/lib/page/setting/setting.dart
+++ b/lib/page/setting/setting.dart
@@ -9,6 +9,7 @@ import 'dart:io';
 
 import 'package:file_picker/file_picker.dart';
 import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
 import 'package:flutter_i18n/flutter_i18n.dart';
 import 'package:get_it/get_it.dart';
 import 'package:signals/signals_flutter.dart';
@@ -62,6 +63,8 @@ class SettingWindow extends StatefulWidget {
   State<SettingWindow> createState() => _SettingWindowState();
 }
 
+const int _defaultLowElectricityWarningThreshold = 20;
+
 class _SettingWindowState extends State<SettingWindow> {
   Widget _buildListSubtitle(String text) => Text(
     text,
@@ -84,6 +87,81 @@ class _SettingWindowState extends State<SettingWindow> {
     while (_isSemesterAwareControllerLoading &&
         stopwatch.elapsed < const Duration(seconds: 30)) {
       await Future<void>.delayed(const Duration(milliseconds: 100));
+    }
+  }
+
+  bool get _lowElectricityWarningEnabled =>
+      !preference.contains(
+        preference.Preference.lowElectricityWarningEnabled,
+      ) ||
+      preference.getBool(preference.Preference.lowElectricityWarningEnabled);
+
+  int get _lowElectricityWarningThreshold {
+    final value =
+        preference.contains(
+          preference.Preference.lowElectricityWarningThreshold,
+        )
+        ? preference.getInt(
+            preference.Preference.lowElectricityWarningThreshold,
+          )
+        : _defaultLowElectricityWarningThreshold;
+    return value > 0 ? value : _defaultLowElectricityWarningThreshold;
+  }
+
+  Future<void> _showLowElectricityThresholdDialog() async {
+    var inputText = _lowElectricityWarningThreshold.toString();
+
+    final value = await showDialog<int>(
+      context: context,
+      builder: (context) => AlertDialog(
+        title: Text(
+          FlutterI18n.translate(
+            context,
+            "setting.low_electricity_threshold_dialog.title",
+          ),
+        ),
+        content: TextFormField(
+          autofocus: true,
+          initialValue: inputText,
+          keyboardType: TextInputType.number,
+          inputFormatters: [FilteringTextInputFormatter.digitsOnly],
+          maxLines: 1,
+          onChanged: (value) => inputText = value,
+          decoration: InputDecoration(
+            hintText: FlutterI18n.translate(
+              context,
+              "setting.low_electricity_threshold_dialog.input_hint",
+            ),
+          ),
+        ),
+        actions: [
+          TextButton(
+            onPressed: () => Navigator.pop(context),
+            child: Text(FlutterI18n.translate(context, "cancel")),
+          ),
+          TextButton(
+            onPressed: () {
+              final parsed = int.tryParse(inputText);
+              Navigator.pop(
+                context,
+                parsed == null || parsed <= 0
+                    ? _defaultLowElectricityWarningThreshold
+                    : parsed,
+              );
+            },
+            child: Text(FlutterI18n.translate(context, "confirm")),
+          ),
+        ],
+      ),
+    );
+
+    if (value == null) return;
+    await preference.setInt(
+      preference.Preference.lowElectricityWarningThreshold,
+      value,
+    );
+    if (mounted) {
+      setState(() {});
     }
   }
 
@@ -341,6 +419,56 @@ class _SettingWindowState extends State<SettingWindow> {
                       });
                     },
                   ),
+                ),
+                const Divider(),
+                ListTile(
+                  title: Text(
+                    FlutterI18n.translate(
+                      context,
+                      "setting.low_electricity_warning",
+                    ),
+                  ),
+                  subtitle: Text(
+                    FlutterI18n.translate(
+                      context,
+                      "setting.low_electricity_warning_description",
+                    ),
+                  ),
+                  trailing: Switch(
+                    value: _lowElectricityWarningEnabled,
+                    onChanged: (bool value) async {
+                      await preference.setBool(
+                        preference.Preference.lowElectricityWarningEnabled,
+                        value,
+                      );
+                      if (mounted) {
+                        setState(() {});
+                      }
+                    },
+                  ),
+                ),
+                const Divider(),
+                ListTile(
+                  enabled: _lowElectricityWarningEnabled,
+                  title: Text(
+                    FlutterI18n.translate(
+                      context,
+                      "setting.low_electricity_threshold",
+                    ),
+                  ),
+                  subtitle: Text(
+                    FlutterI18n.translate(
+                      context,
+                      "setting.low_electricity_threshold_description",
+                      translationParams: {
+                        "threshold": _lowElectricityWarningThreshold.toString(),
+                      },
+                    ),
+                  ),
+                  trailing: const Icon(Icons.navigate_next),
+                  onTap: _lowElectricityWarningEnabled
+                      ? _showLowElectricityThresholdDialog
+                      : null,
                 ),
                 const Divider(),
                 ListTile(

--- a/lib/repository/preference.dart
+++ b/lib/repository/preference.dart
@@ -147,6 +147,14 @@ enum Preference {
     key: "classStyleCompletedInnerAlpha",
     type: "double",
   ), // 已完成课程底色透明度
+  lowElectricityWarningEnabled(
+    key: "lowElectricityWarningEnabled",
+    type: "bool",
+  ), // 首页低电量卡片变色提醒
+  lowElectricityWarningThreshold(
+    key: "lowElectricityWarningThreshold",
+    type: "int",
+  ), // 首页低电量卡片变色提醒阈值
   homepageInfoOrder(
     key: "homepageInfoOrder",
     type: "String",


### PR DESCRIPTION
## 变更内容

- 首页电量低于阈值时，电量卡片切换为提醒样式
- 设置页新增“低电量卡片变色提醒”开关
- 支持自定义低电量阈值
- 默认开启，默认阈值为 20 度

## 实现说明

- 提醒样式使用现有主题色 `errorContainer / onErrorContainer`
- 设置项接入现有 `Preference` 枚举
- 不硬编码具体颜色

## 检查

- 已通过相关文件的 `dart analyze`