### PR TITLE
fix: resolve build issue

### DIFF
--- a/windows/CMakeLists.txt
+++ b/windows/CMakeLists.txt
@@ -57,6 +57,13 @@ add_subdirectory("runner")
 # them to the application.
 include(flutter/generated_plugins.cmake)
 
+# Suppress MSVC deprecation of /await and <experimental/coroutine> used by
+# permission_handler_windows until the plugin migrates to C++20 <coroutine>.
+if(TARGET permission_handler_windows_plugin)
+  target_compile_definitions(permission_handler_windows_plugin PRIVATE
+    _SILENCE_EXPERIMENTAL_COROUTINE_DEPRECATION_WARNINGS)
+endif()
+
 
 # === Installation ===
 # Support files are copied into place next to the executable, so that it can


### PR DESCRIPTION
该PR是对 #156 中提到的构建失败的一个修复，修复了 XDYou 在 Windows 和 Android 上的构建失败的问题。

从提交记录来看，构建失败的原因来自于 [feat: update dep version](https://github.com/BenderBlog/traintime_pda/commit/95cf532f)

## 具体修改

1. `android/app/build.gradle`：在 `plugins` 中新增 `id("org.jetbrains.kotlin.android")`。由于 App 模块已经用了 plugin.compose 和 plugin.serialization 这两个 Kotlin 插件，升级到 AGP 9.2 / Flutter 3.44 后，需要显式声明 Kotlin Android 插件作为前提，不能再依赖 Flutter Gradle 插件自动注入。

2. `android/build.gradle`：新增 org.jetbrains.kotlin.android 的 root 声明；把 plugin.serialization 改成 apply false；在 subprojects 里统一 apply plugin: 'org.jetbrains.kotlin.android'。这个修改让所有子项目（包括 home_widget 等插件）使用同一版本 Kotlin，避免版本冲突，同时 serialization 作为 root 插件只应该声明版本，真正生效要交给具体模块去 apply。

3. `windows/CMakeLists.txt`： 给 `permission_handler_windows_plugin` 加上 `_SILENCE_EXPERIMENTAL_COROUTINE_DEPRECATION_WARNINGS`。由于 permission_handler_windows 还在用 MSVC 的 `/await 和 `<experimental/coroutine>`，新工具链会报弃用警告，所以先屏蔽警告，等上游插件迁移到 C++20 <coroutine> 后再去掉。

## 相关报错

Windows: 
```
C:\Program Files\Microsoft Visual Studio\18\Community\VC\Tools\MSVC\14.51.36231\include\experimental\coroutine(37,1): error C2338: static assertion failed: 'error STL1011: The /await compiler option, <experimental/coroutine>, <experimental/generator>, and <experimental/resumable> are deprecated by Microsoft and will be REMOVED SOON. They are superseded by the C++20 <coroutine> and C++23 <generator> headers. You can define _SILENCE_EXPERIMENTAL_COROUTINE_DEPRECATION_WARNINGS to suppress this error for now.' [D:\jobs\gitrepo\traintime_pda\build\windows\x64\plugins\permission_handler_windows\permission_handler_windows_plugin.vcxproj]
Building Windows application...                                    19.4s
Build process failed.
```

Android: 
```
FAILURE: Build failed with an exception.

* Where:
Build file 'D:\jobs\gitrepo\traintime_pda\android\app\build.gradle' line: 32

* What went wrong:
A problem occurred evaluating project ':app'.
> Could not find method kotlin() for arguments [build_38ovk2o7ixcbr940qerpnegdf$_run_closure2@75f69115] on project ':app' of type org.gradle.api.Project.

* Try:
> Run with --stacktrace option to get the stack trace.
> Run with --info or --debug option to get more log output.
> Run with --scan to get full insights from a Build Scan (powered by Develocity).
> Get more help at https://help.gradle.org.

BUILD FAILED in 1s
Running Gradle task 'assembleDebug'...                           1,902ms
Gradle task assembleDebug failed with exit code 1
```