### PR TITLE
refactor: narrow search result card max width to 160

### DIFF
--- a/lib/page/library/search_book_constant.dart
+++ b/lib/page/library/search_book_constant.dart
@@ -2,4 +2,4 @@
 // SPDX-License-Identifier: MPL-2.0
 
 const double searchPanelMaxWidth = 800;
-const double resultCardMaxWidth = 180;
+const double resultCardMaxWidth = 160;


### PR DESCRIPTION
避免在查询藏书时渲染过宽的单一列